### PR TITLE
feat: add eRadar360 board description, build config, and example

### DIFF
--- a/examples/eradar360/build.yaml
+++ b/examples/eradar360/build.yaml
@@ -1,0 +1,115 @@
+# eRadar360 / Aegis One — Build Configuration
+# Usage: ebuild build
+# This configures the full firmware build for the eRadar360 platform
+
+name: eradar360-firmware
+version: "1.0.0"
+
+toolchain:
+  compiler: gcc
+  arch: arm64
+  prefix: aarch64-linux-gnu-
+
+targets:
+  # Main application — runs on RK3588S (Linux userspace)
+  - name: eradar360-app
+    type: executable
+    sources: ["src/app/*.c", "src/app/*.cpp"]
+    include_dirs: ["include", "include/radar", "include/v2x", "include/ai"]
+    cflags: ["-O2", "-Wall", "-march=armv8.2-a+dotprod"]
+    ldflags: ["-lpthread", "-lm", "-ldl"]
+    deps: [libradar, libv2x, libai, libdisplay, libgps, liblaser]
+
+  # Radar signal processing library
+  - name: libradar
+    type: static_library
+    sources: ["src/radar/*.c"]
+    include_dirs: ["include/radar"]
+    cflags: ["-O3", "-march=armv8.2-a+dotprod", "-ffast-math"]
+
+  # V2X DSRC/C-V2X message parser
+  - name: libv2x
+    type: static_library
+    sources: ["src/v2x/*.c"]
+    include_dirs: ["include/v2x"]
+    cflags: ["-O2", "-Wall"]
+
+  # AI threat classifier (NPU inference engine)
+  - name: libai
+    type: static_library
+    sources: ["src/ai/*.c", "src/ai/*.cpp"]
+    include_dirs: ["include/ai", "external/rknn_api/include"]
+    cflags: ["-O2", "-Wall"]
+    ldflags: ["-lrknn_api"]
+
+  # AMOLED display driver + UI renderer
+  - name: libdisplay
+    type: static_library
+    sources: ["src/display/*.c"]
+    include_dirs: ["include/display"]
+    cflags: ["-O2"]
+
+  # GPS + cloud database client
+  - name: libgps
+    type: static_library
+    sources: ["src/gps/*.c"]
+    include_dirs: ["include/gps"]
+    cflags: ["-O2"]
+
+  # Laser detection signal processor
+  - name: liblaser
+    type: static_library
+    sources: ["src/laser/*.c"]
+    include_dirs: ["include/laser"]
+    cflags: ["-O2", "-ffast-math"]
+
+  # STM32H7B3 co-processor firmware (cross-compiled ARM Cortex-M7)
+  - name: eradar360-coprocessor
+    type: executable
+    sources: ["src/coprocessor/*.c"]
+    include_dirs: ["include/coprocessor"]
+    cflags: ["-mcpu=cortex-m7", "-mthumb", "-mfpu=fpv5-d16", "-mfloat-abi=hard", "-Os"]
+    ldflags: ["-T", "linker/stm32h7b3.ld", "-nostartfiles", "-lm"]
+    toolchain_override:
+      compiler: gcc
+      arch: arm
+      prefix: arm-none-eabi-
+
+system:
+  hostname: eradar360
+  init: busybox
+  image_format: ext4
+  image_size_mb: 128
+
+  users:
+    - name: root
+      shell: /bin/sh
+
+  kernel:
+    source: /path/to/linux
+    defconfig: rockchip_linux_defconfig
+    extra_config:
+      - CONFIG_SPI_ROCKCHIP=y
+      - CONFIG_I2C_RK3X=y
+      - CONFIG_DRM_ROCKCHIP=y
+      - CONFIG_ROCKCHIP_RKNPU=m
+      - CONFIG_CAN=y
+      - CONFIG_CAN_MCP251X=m
+      - CONFIG_GPS_UBX=m
+
+  packages:
+    - name: zlib
+    - name: mbedtls
+
+firmware:
+  rtos: none
+  board: rk3588s
+  flash_tool: rkdeveloptool
+
+pipeline:
+  steps:
+    - analyze: hardware/board/eradar360.yaml
+    - build: eradar360-coprocessor
+    - build: eradar360-app
+    - flash_coprocessor: stm32h7b3
+    - package: eradar360-firmware-v${version}.img

--- a/examples/eradar360/eos.yaml
+++ b/examples/eradar360/eos.yaml
@@ -1,0 +1,295 @@
+# ═══════════════════════════════════════════════════════════════
+# eRadar360 / Aegis One — Full ebuild Pipeline Configuration
+# ═══════════════════════════════════════════════════════════════
+#
+# This file ties the eRadar360 hardware CAD files to ebuild's
+# build pipeline, generating a bootable firmware image.
+#
+# Usage:
+#   cd examples/eradar360
+#   ebuild pipeline --board rk3588s --hardware ../../hardware/board/eradar360.yaml
+#
+# Or step-by-step:
+#   1. ebuild analyze --file ../../hardware/board/eradar360.yaml -o _build/configs
+#   2. ebuild build
+#   3. ebuild firmware --board rk3588s
+#   4. ebuild system --format ext4 --size 128
+#   5. ebuild package --output eradar360-v1.0.0.img
+#
+# CAD Source Files (Products-HW-designs/eRadar360_CAD/):
+#   - eradar360.net          → KiCad netlist (component + pin data)
+#   - bom.csv                → Bill of materials (65+ components)
+#   - pcb_stackup.txt        → 10-layer PCB stackup
+#   - decoupling_cap_map.csv → Capacitor placement map
+#   - antenna_design.md      → SIW phased array specs
+#   - bring_up_guide.md      → Board test procedures
+# ═══════════════════════════════════════════════════════════════
+
+project:
+  name: eradar360
+  version: "1.0.0"
+  description: "Next-gen driver awareness system with V2X, AI, and 360° phased-array radar"
+  license: proprietary
+  board: eradar360-v1
+
+workspace:
+  backend: ninja
+  build_dir: _build
+
+# ─── Hardware Source (input to ebuild analyze) ───────────────
+hardware:
+  board_yaml: ../../hardware/board/eradar360.yaml
+  cad_sources:
+    netlist: ../../../Products-HW-designs/eRadar360_CAD/eradar360.net
+    bom: ../../../Products-HW-designs/eRadar360_CAD/bom.csv
+    stackup: ../../../Products-HW-designs/eRadar360_CAD/pcb_stackup.txt
+    decoupling: ../../../Products-HW-designs/eRadar360_CAD/decoupling_cap_map.csv
+
+# ─── Toolchains ──────────────────────────────────────────────
+toolchains:
+  main:
+    target: aarch64-linux-gnu
+    compiler: gcc
+    arch: arm64
+    prefix: aarch64-linux-gnu-
+    cflags: ["-O2", "-Wall", "-march=armv8.2-a+dotprod"]
+
+  coprocessor:
+    target: arm-none-eabi
+    compiler: gcc
+    arch: arm
+    prefix: arm-none-eabi-
+    cflags: ["-mcpu=cortex-m7", "-mthumb", "-mfpu=fpv5-d16", "-mfloat-abi=hard", "-Os"]
+
+# ─── Build Targets ───────────────────────────────────────────
+targets:
+  # ── Main Application (RK3588S / Linux userspace) ──
+  - name: eradar360-app
+    type: executable
+    toolchain: main
+    sources:
+      - src/main.c
+      - src/app/*.c
+    includes:
+      - include/
+    depends: [libradar, libv2x, libai, libdisplay, libgps, liblaser, libobd]
+    ldflags: ["-lpthread", "-lm", "-ldl"]
+
+  # ── Radar Signal Processing ──
+  - name: libradar
+    type: static_library
+    toolchain: main
+    sources:
+      - src/radar/radar_core.c
+      - src/radar/fft_processor.c
+      - src/radar/beam_steering.c
+      - src/radar/awr2944_driver.c
+      - src/radar/signal_classifier.c
+    includes:
+      - include/radar/
+    cflags: ["-O3", "-ffast-math"]
+
+  # ── V2X Message Parser ──
+  - name: libv2x
+    type: static_library
+    toolchain: main
+    sources:
+      - src/v2x/v2x_core.c
+      - src/v2x/dsrc_parser.c
+      - src/v2x/cv2x_parser.c
+      - src/v2x/bsm_decoder.c
+      - src/v2x/tekton3_driver.c
+    includes:
+      - include/v2x/
+
+  # ── AI Threat Classifier (NPU) ──
+  - name: libai
+    type: static_library
+    toolchain: main
+    sources:
+      - src/ai/threat_classifier.c
+      - src/ai/signal_fingerprint.c
+      - src/ai/npu_inference.c
+      - src/ai/model_loader.c
+    includes:
+      - include/ai/
+      - external/rknn_api/include/
+    ldflags: ["-lrknn_api"]
+
+  # ── AMOLED Display + UI ──
+  - name: libdisplay
+    type: static_library
+    toolchain: main
+    sources:
+      - src/display/display_core.c
+      - src/display/threat_map.c
+      - src/display/direction_arrows.c
+      - src/display/mipi_dsi_driver.c
+    includes:
+      - include/display/
+
+  # ── GPS + Cloud Database ──
+  - name: libgps
+    type: static_library
+    toolchain: main
+    sources:
+      - src/gps/gps_core.c
+      - src/gps/neo_m9n_driver.c
+      - src/gps/cloud_sync.c
+      - src/gps/threat_database.c
+    includes:
+      - include/gps/
+
+  # ── Laser Detection ──
+  - name: liblaser
+    type: static_library
+    toolchain: main
+    sources:
+      - src/laser/laser_core.c
+      - src/laser/apd_processor.c
+      - src/laser/pulse_detector.c
+    includes:
+      - include/laser/
+    cflags: ["-O3", "-ffast-math"]
+
+  # ── OBD-II Vehicle Interface ──
+  - name: libobd
+    type: static_library
+    toolchain: main
+    sources:
+      - src/obd/obd_core.c
+      - src/obd/elm327_driver.c
+      - src/obd/can_parser.c
+      - src/obd/vehicle_context.c
+    includes:
+      - include/obd/
+
+  # ── STM32H7B3 Co-Processor Firmware ──
+  - name: eradar360-coprocessor
+    type: executable
+    toolchain: coprocessor
+    sources:
+      - src/coprocessor/main.c
+      - src/coprocessor/sensor_fusion.c
+      - src/coprocessor/laser_adc.c
+      - src/coprocessor/obd_bridge.c
+      - src/coprocessor/gps_parser.c
+    includes:
+      - include/coprocessor/
+    ldflags: ["-T", "linker/stm32h7b3.ld", "-nostartfiles", "-lm"]
+
+# ─── System Image Configuration ─────────────────────────────
+system:
+  kind: linux
+  hostname: eradar360
+  init: busybox
+  image_format: ext4
+  image_size_mb: 128
+  output: eradar360-firmware-v1.0.0.img
+
+  users:
+    - name: root
+      shell: /bin/sh
+
+  kernel:
+    defconfig: rockchip_linux_defconfig
+    extra_config:
+      - CONFIG_SPI_ROCKCHIP=y
+      - CONFIG_I2C_RK3X=y
+      - CONFIG_SERIAL_8250_DW=y
+      - CONFIG_DRM_ROCKCHIP=y
+      - CONFIG_DRM_PANEL_SIMPLE=y
+      - CONFIG_ROCKCHIP_RKNPU=m
+      - CONFIG_CAN=y
+      - CONFIG_CAN_MCP251X=m
+
+  packages:
+    - name: zlib
+    - name: mbedtls
+
+  # Device tree overlay for eRadar360 peripherals
+  device_tree:
+    base: rk3588s-evb
+    overlays:
+      - eradar360-spi-radar.dtso
+      - eradar360-mipi-display.dtso
+      - eradar360-i2c-sensors.dtso
+      - eradar360-uart-v2x.dtso
+
+  # Files to install into the rootfs
+  install:
+    - src: _build/eradar360-app
+      dst: /usr/bin/eradar360
+    - src: models/threat_classifier.rknn
+      dst: /usr/share/eradar360/models/
+    - src: config/eradar360.conf
+      dst: /etc/eradar360/
+    - src: assets/splash.raw
+      dst: /usr/share/eradar360/
+
+# ─── Firmware Flash Configuration ────────────────────────────
+firmware:
+  board: rk3588s
+  flash_tool: rkdeveloptool
+  partitions:
+    - name: bootloader
+      offset: 0x0
+      size: 4MB
+      image: u-boot-spl.bin
+    - name: uboot
+      offset: 0x400000
+      size: 4MB
+      image: u-boot.itb
+    - name: kernel
+      offset: 0x800000
+      size: 32MB
+      image: Image.gz
+    - name: dtb
+      offset: 0x2800000
+      size: 1MB
+      image: rk3588s-eradar360.dtb
+    - name: rootfs
+      offset: 0x2900000
+      size: 128MB
+      image: eradar360-firmware-v1.0.0.img
+
+  # Co-processor (STM32H7B3) firmware update via I2C bootloader
+  coprocessor:
+    target: stm32h7b3
+    flash_tool: stm32flash
+    binary: _build/eradar360-coprocessor.bin
+    interface: i2c0
+    address: 0x50
+
+# ─── Pipeline Steps ──────────────────────────────────────────
+pipeline:
+  steps:
+    # Step 1: Analyze hardware CAD → generate board/boot/build configs
+    - name: analyze
+      command: ebuild analyze --file ../../hardware/board/eradar360.yaml -o _build/configs
+      description: "Parse board YAML + KiCad netlist → generate EoS configs"
+
+    # Step 2: Build co-processor firmware (ARM Cortex-M7)
+    - name: build-coprocessor
+      command: ebuild build --target eradar360-coprocessor
+      description: "Cross-compile STM32H7B3 sensor fusion firmware"
+
+    # Step 3: Build all libraries + main app (ARM64 Linux)
+    - name: build-app
+      command: ebuild build --target eradar360-app
+      description: "Cross-compile main application + all libraries"
+
+    # Step 4: Build Linux kernel with eRadar360 device tree
+    - name: build-kernel
+      command: ebuild firmware --board rk3588s
+      description: "Build Linux kernel + device tree for RK3588S"
+
+    # Step 5: Assemble rootfs + create system image
+    - name: build-image
+      command: ebuild system --format ext4 --size 128
+      description: "Create ext4 rootfs image with app, models, configs"
+
+    # Step 6: Package final deliverable
+    - name: package
+      command: ebuild package --output eradar360-v1.0.0-release.zip
+      description: "Bundle firmware, SDK, docs into release package"

--- a/examples/eradar360/src/main.c
+++ b/examples/eradar360/src/main.c
@@ -1,0 +1,76 @@
+/*
+ * eRadar360 / Aegis One — Firmware Entry Point
+ * Runs on RK3588S (Linux userspace) — main application
+ *
+ * Build: ebuild build (from examples/eradar360/)
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <unistd.h>
+#include <pthread.h>
+
+/* eRadar360 subsystem headers */
+// #include "radar/radar.h"
+// #include "v2x/v2x.h"
+// #include "ai/threat_classifier.h"
+// #include "display/display.h"
+// #include "gps/gps.h"
+// #include "laser/laser.h"
+
+static volatile int running = 1;
+
+static void signal_handler(int sig) {
+    (void)sig;
+    running = 0;
+}
+
+/* Placeholder subsystem init functions */
+static int radar_init(void) { printf("[RADAR] Initializing AWR2944 front+rear via SPI0/SPI1...\n"); return 0; }
+static int v2x_init(void)   { printf("[V2X]   Initializing TEKTON3 via UART3...\n"); return 0; }
+static int ai_init(void)    { printf("[AI]    Loading threat model on RKNPU (6 TOPS)...\n"); return 0; }
+static int display_init(void){ printf("[DISP]  Initializing AMOLED via MIPI-DSI...\n"); return 0; }
+static int gps_init(void)   { printf("[GPS]   Initializing NEO-M9N via I2C0...\n"); return 0; }
+static int laser_init(void) { printf("[LASER] Initializing 5x InGaAs APD array...\n"); return 0; }
+static int obd_init(void)   { printf("[OBD]   Initializing ELM327 via UART4...\n"); return 0; }
+
+int main(int argc, char *argv[]) {
+    (void)argc; (void)argv;
+
+    printf("═══════════════════════════════════════════\n");
+    printf("  eRadar360 / Aegis One v1.0.0\n");
+    printf("  Driver Awareness System\n");
+    printf("═══════════════════════════════════════════\n\n");
+
+    signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);
+
+    /* Initialize all subsystems */
+    if (radar_init()  != 0) { fprintf(stderr, "Radar init failed\n"); return 1; }
+    if (v2x_init()    != 0) { fprintf(stderr, "V2X init failed\n"); return 1; }
+    if (ai_init()     != 0) { fprintf(stderr, "AI init failed\n"); return 1; }
+    if (display_init()!= 0) { fprintf(stderr, "Display init failed\n"); return 1; }
+    if (gps_init()    != 0) { fprintf(stderr, "GPS init failed\n"); return 1; }
+    if (laser_init()  != 0) { fprintf(stderr, "Laser init failed\n"); return 1; }
+    if (obd_init()    != 0) { fprintf(stderr, "OBD-II init failed\n"); return 1; }
+
+    printf("\n[SYSTEM] All subsystems initialized. Scanning...\n\n");
+
+    /* Main loop — scan, classify, alert */
+    while (running) {
+        /* 1. Read radar FFT data from AWR2944 (SPI) */
+        /* 2. Read V2X BSM messages (UART) */
+        /* 3. Read laser pulses (ADC via co-processor) */
+        /* 4. Read GPS position (I2C) */
+        /* 5. Read OBD-II vehicle state (CAN) */
+        /* 6. Run AI threat classifier on NPU */
+        /* 7. Update display with threat map */
+        /* 8. Generate audio alerts if needed */
+
+        usleep(10000); /* 10ms loop = 100 Hz scan rate */
+    }
+
+    printf("\n[SYSTEM] Shutting down...\n");
+    return 0;
+}

--- a/hardware/board/eradar360.yaml
+++ b/hardware/board/eradar360.yaml
@@ -1,0 +1,129 @@
+# eRadar360 / Aegis One — Hardware Board Description
+# SoC: Rockchip RK3588S (ARM Cortex-A76/A55, 6 TOPS NPU)
+# Use: ebuild analyze hardware/board/eradar360.yaml
+
+board_name: eradar360-v1
+revision: "A"
+
+mcu:
+  part: RK3588S
+  family: RK3588
+  core: cortex-a76
+  clock: 2400 MHz
+  flash: 256MB QSPI NOR (Macronix MX25U25645G)
+  ram: 1GB DDR4-3200 (Samsung K4A8G165WC)
+  voltage: 0.85V core / 1.8V I/O / 3.3V peripherals
+  features: [npu_6tops, mali_g610, pcie3, usb3, mipi_dsi, spi, i2c, uart, hdmi]
+
+peripherals:
+  # Radar subsystem
+  - SPI0: front radar (TI AWR2944, 77GHz FMCW, 4TX/4RX, BGA-232)
+  - SPI1: rear radar (TI AWR2944, 77GHz FMCW, 4TX/4RX, BGA-232)
+  # V2X communication
+  - UART3: V2X transceiver (Autotalks TEKTON3, DSRC 802.11p + C-V2X PC5)
+  # Display
+  - MIPI_DSI: 4" AMOLED display (Samsung AMS395GE04, 480x800, 600 nits)
+  # Sensor fusion co-processor
+  - I2C0: sensor hub (STM32H7B3, ARM Cortex-M7, 280MHz)
+  # GPS
+  - I2C0: GNSS receiver (u-blox NEO-M9N, GPS/GLONASS/Galileo/BeiDou)
+  # Laser detection
+  - ADC0-4: 5x InGaAs APD laser sensors (Hamamatsu G12183-010K via OPA857 TIA)
+  # OBD-II vehicle interface
+  - UART4: OBD-II interpreter (ELM327 + MCP2551 CAN transceiver)
+  # Connectivity
+  - SDIO: Wi-Fi 6 + Bluetooth 5.3 (Qualcomm QCA6174A)
+  # Audio
+  - I2S: 2W class-D amplifier (TI TPA2012D2) + 3.5mm jack
+  # User input
+  - GPIO: 3x tactile buttons (MENU, MUTE, MARK)
+  # Debug
+  - UART2: debug console (115200 baud)
+  - JTAG: 10-pin Cortex debug header (J6)
+
+memory_map:
+  flash_base: 0x00000000
+  flash_size: 0x2000000     # 256MB NOR flash
+  ram_base: 0x00200000
+  ram_size: 0x40000000      # 1GB DDR4
+  spi0_base: 0xFE610000     # SPI0 controller (front radar)
+  spi1_base: 0xFE620000     # SPI1 controller (rear radar)
+  uart2_base: 0xFEB50000    # UART2 debug
+  uart3_base: 0xFEB60000    # UART3 V2X
+  i2c0_base: 0xFEA90000    # I2C0 bus
+  mipi_dsi_base: 0xFDE20000 # MIPI-DSI display controller
+  npu_base: 0xFDAB0000      # RKNPU (6 TOPS)
+
+boot:
+  recovery_pin: GPIO0_A0 (active low, pull-up)
+  led_status: GPIO0_A1 (green status LED)
+  watchdog: 10000ms
+  bootloader: U-Boot (SPL + ATF)
+
+power:
+  main_supply: 5V USB-C (3A max) or 12V OBD-II
+  regulators:
+    - BUCK1 3.3V (TPS65219, 1.5A — digital logic, GPS, CAN, V2X)
+    - BUCK2 1.8V (TPS65219, 1A — DDR4, MIPI I/O, radar I/O)
+    - BUCK3 0.85V (TPS65219, 4A — RK3588S CPU + NPU + GPU core)
+    - BUCK4 1.1V (TPS65219, 800mA — AWR2944 x2 radar core)
+    - BOOST 12V (TPS61046, 200mA — OLED ELVDD)
+  total_power: 10W max (all subsystems active)
+  sleep_power: 0.5W (STM32 + 3.3V + 5V only)
+
+connectors:
+  - USB-C (power + data, J1)
+  - 3.5mm TRRS audio jack (J2)
+  - OBD-II SAE J1962 male (J3, 12V vehicle power + CAN bus)
+  - 40-pin FPC (OLED display, J4)
+  - SMA female (V2X antenna, J5)
+  - 10-pin 1.27mm JTAG (debug, J6)
+  - U.FL coax (GPS antenna, J7)
+
+antennas:
+  front_radar:
+    type: SIW phased array
+    elements: 8x8 (64)
+    substrate: Rogers RO4003C
+    gain: 24 dBi
+    steering: ±45° azimuth, ±30° elevation
+    frequency: 33.4-36.0 GHz (Ka-band)
+  rear_radar:
+    type: SIW phased array
+    elements: 4x4 (16)
+    substrate: Rogers RO4003C
+    gain: 18 dBi
+    steering: ±30° azimuth
+    frequency: 33.4-36.0 GHz (Ka-band)
+  k_band:
+    type: 2x2 microstrip patch
+    gain: 12 dBi
+    frequency: 24.05-24.25 GHz
+  x_band:
+    type: single patch + LNA
+    gain: 7 dBi
+    frequency: 10.5-10.55 GHz
+  gps:
+    type: ceramic patch (Taoglas AP.25F)
+    gain: 4 dBi
+  v2x:
+    type: external SMA (5.9 GHz DSRC/C-V2X)
+
+pcb:
+  layers: 10
+  material: Rogers RO4003C (RF layers 1-2) + Isola 370HR (layers 3-10)
+  dimensions: 120mm x 85mm
+  thickness: 1.6mm
+  surface_finish: ENIG
+  impedance: 50Ω single-ended, 100Ω differential
+
+use_case: |
+  Next-generation driver awareness system (radar detector + V2X + AI).
+  Dual SIW phased-array antennas provide 360° Ka/K/Ku/X-band coverage
+  with electronic beam steering. V2X chip receives law enforcement
+  broadcasts from smart infrastructure before radar is detectable.
+  6 TOPS NPU fingerprints radar signatures by pulse pattern for 97%
+  false-alert suppression. OBD-II integration adds vehicle context
+  (speed, cruise state) to eliminate irrelevant alerts. GPS enables
+  cloud-shared threat database. 4" AMOLED shows directional threat map.
+  Target retail price: $699, BOM cost: ~$330.


### PR DESCRIPTION
Adds ebuild support for the eRadar360 (Aegis One) driver awareness system.

### Files
- **hardware/board/eradar360.yaml** — Board description for `ebuild analyze` (RK3588S + AWR2944 + TEKTON3 + all peripherals)
- **examples/eradar360/build.yaml** — Full build config (7 targets: app + 5 libs + co-processor firmware)
- **examples/eradar360/src/main.c** — Firmware entry point skeleton

### Usage
```bash
ebuild analyze hardware/board/eradar360.yaml
cd examples/eradar360 && ebuild build
```