### PR TITLE
fix: link shared libraries with shared mode

### DIFF
--- a/ebuild/build/ninja_backend.py
+++ b/ebuild/build/ninja_backend.py
@@ -69,6 +69,10 @@ class NinjaBackend:
             "  command = $cc $ldflags $in -o $out $libs",
             "  description = LINK $out",
             "",
+            "rule link_shared",
+            "  command = $cc -shared $ldflags $in -o $out $libs",
+            "  description = LINK_SHARED $out",
+            "",
             "rule ar_rule",
             "  command = $ar rcs $out $in",
             "  description = AR $out",
@@ -136,7 +140,7 @@ class NinjaBackend:
                 else:
                     ext = ".so"
                 out = str(self.build_dir / f"lib{target.name}{ext}")
-                rule = "ar_rule" if target.target_type == "static_library" else "link"
+                rule = "ar_rule" if target.target_type == "static_library" else "link_shared"
                 lines.append(
                     f"build {out}: {rule} {' '.join(obj_files)}"
                 )

--- a/tests/ebuild/test_ninja_backend.py
+++ b/tests/ebuild/test_ninja_backend.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+
+from ebuild.build.ninja_backend import NinjaBackend
+from ebuild.core.config import ProjectConfig, TargetConfig
+
+
+def test_shared_library_uses_shared_link_rule(tmp_path):
+    config = ProjectConfig(
+        name="shared-example",
+        version="1.0.0",
+        source_dir=tmp_path,
+        targets=[
+            TargetConfig(
+                name="example",
+                target_type="shared_library",
+                sources=["example.c"],
+            )
+        ],
+    )
+    toolchain = SimpleNamespace(cc="cc", cxx="c++", ar="ar")
+
+    NinjaBackend(config, tmp_path / "build", toolchain).generate()
+
+    ninja_file = (tmp_path / "build" / "build.ninja").read_text(encoding="utf-8")
+    assert "rule link_shared\n  command = $cc -shared" in ninja_file
+    assert "build " in ninja_file
+    assert ": link_shared " in ninja_file


### PR DESCRIPTION
## Problem

The Ninja backend currently links `shared_library` targets using the regular `link` rule. That rule does not pass the compiler's `-shared` option, so the compiler may attempt to produce an executable instead of a shared library.

This can result in linker failures such as a missing `main` entry point or an output that does not behave as the requested shared library.

## Solution

- Added a dedicated `link_shared` Ninja rule.
- Added the `-shared` compiler option to that rule.
- Updated `shared_library` targets to use `link_shared`.
- Kept executable and static-library behavior unchanged.
- Added a regression test for the generated Ninja file.

## Testing

Executed:

`pytest tests -q`

Result:

`73 passed`

The new regression test was also run against the previous implementation and failed when the shared-link rule was removed.

## Additional considerations

The current eBuild toolchain resolver produces GCC-compatible toolchains, for which `-shared` is supported. Toolchains with different shared-library flags may require a toolchain-specific option in the future.