### PR TITLE
fix: validate target schema before config parsing

### DIFF
--- a/ebuild/core/config.py
+++ b/ebuild/core/config.py
@@ -91,10 +91,31 @@ class ProjectConfig:
         return [t.name for t in self.targets]
 
 
-def _parse_target(raw: Dict[str, Any]) -> TargetConfig:
+def _parse_target(raw: Any) -> TargetConfig:
     """Parse a single target dictionary into a TargetConfig."""
+    if not isinstance(raw, dict):
+        raise ConfigError(
+            f"Invalid target definition: expected a YAML mapping, got {type(raw).__name__}."
+        )
+
+    target_name = raw.get("name", "")
+    for field_name in (
+        "sources", "includes", "cflags", "ldflags", "defines", "depends", "uses"
+    ):
+        value = raw.get(field_name, [])
+        if not isinstance(value, list):
+            label = target_name or "<unnamed>"
+            raise ConfigError(
+                f"Target '{label}' field '{field_name}' must be a list."
+            )
+        if not all(isinstance(item, str) for item in value):
+            label = target_name or "<unnamed>"
+            raise ConfigError(
+                f"Target '{label}' field '{field_name}' must contain only strings."
+            )
+
     target = TargetConfig(
-        name=raw.get("name", ""),
+        name=target_name,
         target_type=raw.get("type", ""),
         sources=raw.get("sources", []),
         includes=raw.get("includes", []),
@@ -159,6 +180,8 @@ def load_config(config_path: str | Path) -> ProjectConfig:
     # --- backend (optional) ---
     backend = raw.get("backend", "auto")
     backend_config = raw.get("backend_config", {})
+    if not isinstance(backend_config, dict):
+        raise ConfigError("'backend_config' must be a mapping.")
 
     # For system builds, pull from 'system' section
     if raw.get("system") and isinstance(raw["system"], dict):

--- a/tests/ebuild/test_config_validation.py
+++ b/tests/ebuild/test_config_validation.py
@@ -1,0 +1,61 @@
+import pytest
+import yaml
+
+from ebuild.core.config import ConfigError, load_config
+
+
+def write_config(tmp_path, data):
+    config_path = tmp_path / "build.yaml"
+    config_path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return config_path
+
+
+@pytest.mark.parametrize("invalid_target", ["app", 42, None])
+def test_target_definition_must_be_mapping(tmp_path, invalid_target):
+    path = write_config(
+        tmp_path,
+        {"project": {"name": "demo"}, "targets": [invalid_target]},
+    )
+
+    with pytest.raises(ConfigError, match="expected a YAML mapping"):
+        load_config(path)
+
+
+@pytest.mark.parametrize("field_name", [
+    "sources", "includes", "cflags", "ldflags", "defines", "depends", "uses"
+])
+def test_target_collection_fields_must_be_lists(tmp_path, field_name):
+    target = {"name": "app", "type": "executable", "sources": ["main.c"]}
+    target[field_name] = "not-a-list"
+    path = write_config(
+        tmp_path,
+        {"project": {"name": "demo"}, "targets": [target]},
+    )
+
+    with pytest.raises(ConfigError, match=rf"field '{field_name}' must be a list"):
+        load_config(path)
+
+
+def test_target_collection_items_must_be_strings(tmp_path):
+    path = write_config(
+        tmp_path,
+        {
+            "project": {"name": "demo"},
+            "targets": [
+                {"name": "app", "type": "executable", "sources": ["main.c", 7]}
+            ],
+        },
+    )
+
+    with pytest.raises(ConfigError, match="must contain only strings"):
+        load_config(path)
+
+
+def test_backend_config_must_be_mapping(tmp_path):
+    path = write_config(
+        tmp_path,
+        {"project": {"name": "demo"}, "backend_config": ["invalid"]},
+    )
+
+    with pytest.raises(ConfigError, match="'backend_config' must be a mapping"):
+        load_config(path)


### PR DESCRIPTION
## Problem

Malformed target entries in `build.yaml` currently reach the parser as arbitrary YAML values. A scalar target such as a string, number, or null then raises an internal `AttributeError` instead of the documented `ConfigError`.

Collection fields such as `sources`, `depends`, and compiler flags also accept scalar or mixed-type values. These invalid values fail later during dependency resolution or Ninja generation, far from the configuration error. A non-mapping `backend_config` similarly crashes when backend sections are merged.

## Solution

- Validate that every target definition is a YAML mapping.
- Require target collection fields to be lists containing only strings.
- Validate that `backend_config` is a mapping before merging backend-specific settings.
- Return contextual `ConfigError` messages naming the invalid target field.
- Add parameterized regression coverage for malformed target shapes and fields.

## Testing

Executed:

`pytest tests -q`

Result:

`84 passed`

The regression tests were also run without the new target-type guard and reproduced the previous `AttributeError` failures for string, integer, and null target definitions.

## Additional considerations

This change validates the schema already expected by the build pipeline. Valid configurations are unchanged. Package and toolchain schema validation remain outside this PR.