### PR TITLE
fix(graph): make topological sort deterministic

### DIFF
--- a/ebuild/core/graph.py
+++ b/ebuild/core/graph.py
@@ -69,6 +69,11 @@ class DependencyGraph:
         """Return nodes in build order (dependencies first).
 
         Uses Kahn's algorithm. Raises CycleError if a cycle exists.
+
+        Independent targets are emitted in sorted name order so the result
+        is stable across processes. Walking ``self._nodes`` (a set) directly
+        made ``ebuild info`` and generated ``build.ninja`` files change
+        between runs even when the graph had not.
         """
         in_degree: Dict[str, int] = {n: 0 for n in self._nodes}
         reverse_adj: Dict[str, Set[str]] = defaultdict(set)
@@ -78,8 +83,10 @@ class DependencyGraph:
                 reverse_adj[dep].add(dependent)
                 in_degree[dependent] = in_degree.get(dependent, 0) + 1
 
+        # Ready nodes must be sorted: set iteration order is not part of
+        # the language spec, and dependents are already sorted below.
         queue: deque[str] = deque()
-        for node in self._nodes:
+        for node in sorted(self._nodes):
             if in_degree.get(node, 0) == 0:
                 queue.append(node)
 

--- a/tests/unit/test_unit_core.py
+++ b/tests/unit/test_unit_core.py
@@ -1,6 +1,101 @@
-import unittest
-class TestEBuildUnit(unittest.TestCase):
-    def test_dependency_graph_sort(self):
-        deps = {"b": ["a"], "c": ["b"]}
-        sorted_deps = ["a", "b", "c"]
-        self.assertEqual(sorted_deps[-1], "c")
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 EoS Project
+
+"""Unit tests for the build dependency graph.
+
+These tests import only ebuild.core.graph (no yaml/click) so they run on a
+bare Python install. They replace a previous placeholder that did not
+exercise the graph at all.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from ebuild.core.graph import (
+    CycleError,
+    DependencyGraph,
+    build_dependency_graph,
+)
+
+
+class TestDependencyGraph:
+    def test_empty_graph(self):
+        assert DependencyGraph().topological_sort() == []
+
+    def test_single_node(self):
+        graph = DependencyGraph()
+        graph.add_node("app")
+        assert graph.topological_sort() == ["app"]
+
+    def test_linear_chain(self):
+        graph = DependencyGraph()
+        graph.add_edge("app", "lib")
+        graph.add_edge("lib", "core")
+        assert graph.topological_sort() == ["core", "lib", "app"]
+
+    def test_diamond_dependency(self):
+        graph = DependencyGraph()
+        graph.add_edge("app", "liba")
+        graph.add_edge("app", "libb")
+        graph.add_edge("liba", "core")
+        graph.add_edge("libb", "core")
+        assert graph.topological_sort() == ["core", "liba", "libb", "app"]
+
+    def test_independent_nodes_have_stable_order(self):
+        """Unrelated targets must come out in sorted order, not hash order.
+
+        Nodes are inserted out of alphabetical order on purpose. Without a
+        sorted ready queue the result follows set iteration order, which is
+        not part of the language spec and is not alphabetical here.
+        """
+        graph = DependencyGraph()
+        for name in ["z", "m", "a", "y", "b"]:
+            graph.add_node(name)
+        assert graph.topological_sort() == ["a", "b", "m", "y", "z"]
+
+    def test_cycle_raises(self):
+        graph = DependencyGraph()
+        graph.add_edge("a", "b")
+        graph.add_edge("b", "a")
+        with pytest.raises(CycleError, match="a, b"):
+            graph.topological_sort()
+
+    def test_self_cycle_raises(self):
+        graph = DependencyGraph()
+        graph.add_edge("app", "app")
+        with pytest.raises(CycleError, match="app"):
+            graph.topological_sort()
+
+    def test_all_dependencies_is_transitive(self):
+        graph = DependencyGraph()
+        graph.add_edge("app", "lib")
+        graph.add_edge("lib", "core")
+        assert graph.all_dependencies("app") == {"lib", "core"}
+        assert graph.all_dependencies("core") == set()
+
+    def test_dependents_of(self):
+        graph = DependencyGraph()
+        graph.add_edge("app", "lib")
+        graph.add_edge("test", "lib")
+        assert graph.dependents_of("lib") == {"app", "test"}
+        assert graph.dependents_of("app") == set()
+
+
+class TestBuildDependencyGraph:
+    def test_orders_targets_from_config_objects(self):
+        targets = [
+            SimpleNamespace(name="app", depends=["lib"]),
+            SimpleNamespace(name="lib", depends=["core"]),
+            SimpleNamespace(name="core", depends=[]),
+        ]
+        graph = build_dependency_graph(targets)
+        assert graph.topological_sort() == ["core", "lib", "app"]
+
+    def test_cycle_in_targets_raises(self):
+        targets = [
+            SimpleNamespace(name="a", depends=["b"]),
+            SimpleNamespace(name="b", depends=["a"]),
+        ]
+        with pytest.raises(CycleError):
+            build_dependency_graph(targets)


### PR DESCRIPTION
## Summary

`DependencyGraph.topological_sort` is used by `ebuild info` and by the Ninja backend to decide build order. Kahn's algorithm already sorted dependents after a node was built, but it seeded the ready queue by iterating a Python `set`. Set iteration order is not part of the language spec, so independent targets could appear in a different order from one process to the next.

The same `build.yaml` could therefore produce a different build plan and a different `build.ninja` even when the project had not changed. This change makes that order stable.

## Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation only
- [ ] style: Formatting, no code change
- [ ] refactor: Code restructuring without behavior change
- [x] test: Add or fix tests
- [ ] build: Build system or dependency changes
- [ ] ci: CI/CD pipeline changes
- [ ] perf: Performance improvement

## Changes

- Sort the ready queue when seeding Kahn's algorithm so independent targets are emitted in name order. Dependents were already sorted; the initial queue was the missing piece.
- Replace the placeholder in `tests/unit/test_unit_core.py` with tests that import `ebuild.core.graph`. The previous test constructed a Python list and asserted that `'c'` was last; it never called ebuild.

## Testing

- [x] Unit tests pass (`pytest tests/unit tests/ebuild -v` — 79 passed)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [x] New tests added for new functionality

The new suite covers empty graphs, linear chains, diamond dependencies, cycle detection, transitive queries, and a dedicated determinism case for independent nodes.

To confirm the determinism test is meaningful, `sorted()` was temporarily removed from the ready queue. `test_independent_nodes_have_stable_order` failed with a scrambled order instead of alphabetical. Restoring the sort brought the test back to passing.

## Pre-Submission Checklist

- [ ] Code compiles without warnings (-Wall -Wextra -Werror for C)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Documentation updated if API changed
- [x] Commit messages follow <type>(<scope>): <description> convention
- [x] Branch is rebased on latest master