### PR TITLE
fix(packages): extract archives on Python 3.8–3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Package fetch:** `tar.extractall(..., filter="data")` is Python 3.12-only. Extraction now uses that filter when available and a member-path check on 3.8–3.11, so `ebuild` package installs work on the declared Python range. Zip extraction now uses `Path.relative_to` so a sibling path is not mistaken for a child of the extract directory.
+
 ## [3.0.1] - 2026-05-16
 
 ### Production Release — Unified EmbeddedOS-org v3.0.1

--- a/ebuild/packages/fetcher.py
+++ b/ebuild/packages/fetcher.py
@@ -109,27 +109,78 @@ class PackageFetcher:
         try:
             if name.endswith((".tar.gz", ".tgz")):
                 with tarfile.open(archive_path, "r:gz") as tar:
-                    tar.extractall(extract_to, filter="data")
+                    self._extract_tar(tar, extract_to)
             elif name.endswith((".tar.bz2", ".tbz2")):
                 with tarfile.open(archive_path, "r:bz2") as tar:
-                    tar.extractall(extract_to, filter="data")
+                    self._extract_tar(tar, extract_to)
             elif name.endswith((".tar.xz", ".txz")):
                 with tarfile.open(archive_path, "r:xz") as tar:
-                    tar.extractall(extract_to, filter="data")
+                    self._extract_tar(tar, extract_to)
             elif name.endswith(".zip"):
                 with zipfile.ZipFile(archive_path, "r") as zf:
-                    for member in zf.namelist():
-                        member_path = Path(extract_to) / member
-                        resolved = member_path.resolve()
-                        if not str(resolved).startswith(str(Path(extract_to).resolve())):
-                            raise FetchError(
-                                f"Zip path traversal detected: {member}"
-                            )
-                    zf.extractall(extract_to)
+                    self._extract_zip(zf, extract_to)
             else:
                 raise FetchError(f"Unsupported archive format: {archive_path.name}")
-        except (tarfile.TarError, zipfile.BadZipFile) as e:
+        except FetchError:
+            raise
+        except (tarfile.TarError, zipfile.BadZipFile, OSError) as e:
             raise FetchError(f"Failed to extract {archive_path.name}: {e}")
+
+    @staticmethod
+    def _path_is_within(base: Path, target: Path) -> bool:
+        """Return True if *target* resolves strictly inside *base*.
+
+        Uses Path.relative_to rather than a string prefix check so that
+        ``/tmp/extract-evil`` is not treated as inside ``/tmp/extract``.
+        """
+        try:
+            target.resolve().relative_to(base.resolve())
+            return True
+        except ValueError:
+            return False
+
+    def _extract_tar(self, tar: tarfile.TarFile, extract_to: Path) -> None:
+        """Extract a tar archive, compatible with Python 3.8–3.11 and 3.12+.
+
+        ``filter='data'`` (CVE-2007-4559 mitigation) was added in Python 3.12.
+        README and pyproject.toml claim support for Python 3.8+, so older
+        interpreters must extract without that keyword and with an explicit
+        member-path check instead.
+        """
+        if hasattr(tarfile, "data_filter"):
+            try:
+                tar.extractall(extract_to, filter="data")
+            except Exception as e:
+                # 3.12+ raises FilterError / OutsideDestinationError for
+                # members that would extract outside extract_to.
+                err_name = type(e).__name__
+                if "Filter" in err_name or "Outside" in err_name or "Absolute" in err_name:
+                    raise FetchError(f"Tar path traversal detected: {e}") from e
+                raise
+            return
+
+        extract_root = extract_to.resolve()
+        for member in tar.getmembers():
+            dest = extract_to / member.name
+            if not self._path_is_within(extract_root, dest):
+                raise FetchError(f"Tar path traversal detected: {member.name}")
+            if member.issym() or member.islnk():
+                link_dest = dest.parent / member.linkname
+                if Path(member.linkname).is_absolute():
+                    link_dest = Path(member.linkname)
+                if not self._path_is_within(extract_root, link_dest):
+                    raise FetchError(
+                        f"Tar link path traversal detected: {member.name} -> {member.linkname}"
+                    )
+        tar.extractall(extract_to)
+
+    def _extract_zip(self, zf: zipfile.ZipFile, extract_to: Path) -> None:
+        """Extract a zip archive after rejecting path-traversal members."""
+        extract_root = extract_to.resolve()
+        for member in zf.namelist():
+            if not self._path_is_within(extract_root, extract_to / member):
+                raise FetchError(f"Zip path traversal detected: {member}")
+        zf.extractall(extract_to)
 
     def _archive_filename(self, recipe: PackageRecipe) -> str:
         """Derive archive filename from recipe URL."""

--- a/tests/ebuild/test_package_fetcher.py
+++ b/tests/ebuild/test_package_fetcher.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 EoS Project
+
+"""PackageFetcher extraction: Python 3.8+ compatibility and path traversal."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from ebuild.packages.fetcher import FetchError, PackageFetcher
+
+
+def _write_targz(path: Path, files: dict[str, bytes]) -> None:
+    with tarfile.open(path, "w:gz") as tar:
+        for name, data in files.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+
+
+def _write_zip(path: Path, files: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, data in files.items():
+            zf.writestr(name, data)
+
+
+def test_extract_targz_succeeds_on_running_python(tmp_path):
+    """filter='data' is 3.12+; this must still extract on 3.8–3.11."""
+    archive = tmp_path / "pkg.tar.gz"
+    _write_targz(archive, {"hello.txt": b"hello ebuild"})
+    dest = tmp_path / "out"
+
+    PackageFetcher(tmp_path / "dl")._extract(archive, dest)
+
+    assert (dest / "hello.txt").read_bytes() == b"hello ebuild"
+
+
+def test_extract_zip_succeeds(tmp_path):
+    archive = tmp_path / "pkg.zip"
+    _write_zip(archive, {"hello.txt": b"hello zip"})
+    dest = tmp_path / "out"
+
+    PackageFetcher(tmp_path / "dl")._extract(archive, dest)
+
+    assert (dest / "hello.txt").read_bytes() == b"hello zip"
+
+
+def test_extract_tar_rejects_path_traversal(tmp_path):
+    archive = tmp_path / "evil.tar.gz"
+    _write_targz(archive, {"../escaped.txt": b"pwned"})
+    dest = tmp_path / "out"
+    dest.mkdir()
+
+    with pytest.raises(FetchError, match="path traversal"):
+        PackageFetcher(tmp_path / "dl")._extract(archive, dest)
+
+    assert not (tmp_path / "escaped.txt").exists()
+
+
+def test_extract_zip_rejects_path_traversal(tmp_path):
+    archive = tmp_path / "evil.zip"
+    _write_zip(archive, {"../escaped.txt": b"pwned"})
+    dest = tmp_path / "out"
+    dest.mkdir()
+
+    with pytest.raises(FetchError, match="path traversal"):
+        PackageFetcher(tmp_path / "dl")._extract(archive, dest)
+
+    assert not (tmp_path / "escaped.txt").exists()
+
+
+def test_extract_zip_rejects_sibling_prefix_path(tmp_path):
+    """'/tmp/extract' must not match '/tmp/extract-evil' via startswith()."""
+    dest = tmp_path / "extract"
+    dest.mkdir()
+    sibling = tmp_path / "extract-evil.txt"
+    archive = tmp_path / "evil.zip"
+    # namelist entry that resolves to a sibling of dest via ".."
+    _write_zip(archive, {"../extract-evil.txt": b"pwned"})
+
+    with pytest.raises(FetchError, match="path traversal"):
+        PackageFetcher(tmp_path / "dl")._extract(archive, dest)
+
+    assert not sibling.exists()
+
+
+def test_extract_rejects_unknown_format(tmp_path):
+    archive = tmp_path / "pkg.rar"
+    archive.write_bytes(b"not-an-archive")
+
+    with pytest.raises(FetchError, match="Unsupported archive format"):
+        PackageFetcher(tmp_path / "dl")._extract(archive, tmp_path / "out")


### PR DESCRIPTION
tar.extractall(..., filter="data") is 3.12-only, so package installs
crashed on the Python versions README and pyproject.toml still claim
to support. Use the data filter when present and a member-path check
otherwise, and reject zip traversal via Path.relative_to.

Signed-off-by: Noor Nabi <gcnoor6@gmail.com>
Co-authored-by: Cursor <cursoragent@cursor.com>