### PR TITLE
fix(packages): honour explicitly requested package versions

### DIFF
--- a/ebuild/packages/resolver.py
+++ b/ebuild/packages/resolver.py
@@ -36,6 +36,14 @@ class PackageResolver:
     ) -> List[PackageRecipe]:
         """Resolve a list of requested packages into a full build order.
 
+        Version selection:
+            An explicitly requested version pins the package for the whole
+            resolution, no matter where in the dependency graph the package is
+            first reached. Packages requested without a version resolve to the
+            newest one in the registry. Requesting two different versions of
+            the same package is a conflict and raises rather than silently
+            selecting one of them.
+
         Args:
             requested: List of dicts with 'name' and optional 'version' keys.
 
@@ -43,15 +51,22 @@ class PackageResolver:
             List of PackageRecipe in correct build order (dependencies first).
 
         Raises:
-            ResolveError: If a package or dependency cannot be found.
+            ResolveError: If a package or dependency cannot be found, if two
+                incompatible versions of the same package are requested, or if
+                the dependency graph contains a cycle.
         """
         resolved: Dict[str, PackageRecipe] = {}
         graph = DependencyGraph()
 
+        # Collect explicit pins up front. Doing this before walking the graph
+        # is what makes the result independent of request order: otherwise the
+        # first traversal to reach a package fixes its version, and a pin
+        # appearing later in the list is swallowed by the memoization in
+        # _collect().
+        pins = self._collect_pins(requested)
+
         for pkg in requested:
-            name = pkg.get("name", "")
-            version = pkg.get("version")
-            self._collect(name, version, resolved, graph)
+            self._collect(pkg.get("name", ""), pins, resolved, graph)
 
         try:
             order = graph.topological_sort()
@@ -60,10 +75,37 @@ class PackageResolver:
 
         return [resolved[name] for name in order if name in resolved]
 
+    @staticmethod
+    def _collect_pins(requested: List[Dict[str, str]]) -> Dict[str, str]:
+        """Map package name → explicitly requested version.
+
+        Raises:
+            ResolveError: If the same package is requested at two different
+                versions.
+        """
+        pins: Dict[str, str] = {}
+
+        for pkg in requested:
+            name = pkg.get("name", "")
+            version = pkg.get("version")
+            if not version:
+                continue
+
+            existing = pins.get(name)
+            if existing is not None and existing != version:
+                raise ResolveError(
+                    f"Conflicting versions requested for package '{name}': "
+                    f"'{existing}' and '{version}'. "
+                    "Request a single version of each package."
+                )
+            pins[name] = version
+
+        return pins
+
     def _collect(
         self,
         name: str,
-        version: Optional[str],
+        pins: Dict[str, str],
         resolved: Dict[str, PackageRecipe],
         graph: DependencyGraph,
     ) -> None:
@@ -71,6 +113,7 @@ class PackageResolver:
         if name in resolved:
             return
 
+        version = pins.get(name)
         recipe = self.registry.get(name, version)
         if recipe is None:
             raise ResolveError(
@@ -84,7 +127,7 @@ class PackageResolver:
         graph.add_node(name)
 
         for dep_name in recipe.dependencies:
-            self._collect(dep_name, None, resolved, graph)
+            self._collect(dep_name, pins, resolved, graph)
             graph.add_edge(name, dep_name)
 
     def resolve_single(self, name: str, version: Optional[str] = None) -> PackageRecipe:

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 EoS Project
+
+"""Tests for :mod:`ebuild.packages.resolver`.
+
+Covers version-constraint handling in particular: an explicitly requested
+version must be honoured no matter where in the graph the package is first
+reached, and two mutually exclusive requests must fail loudly rather than
+silently picking one.
+
+These live in tests/unit/ rather than tests/ebuild/ because the "Run unit
+tests" CI step runs tests/unit/; no workflow references tests/ebuild/.
+Importing the registry pulls in pyyaml, which is a declared runtime
+dependency of the package (pyproject.toml), so it is always available.
+"""
+
+import pytest
+
+from ebuild.packages.registry import PackageRegistry
+from ebuild.packages.resolver import PackageResolver, ResolveError
+
+pytestmark = pytest.mark.ebuild
+
+
+def make_registry(tmp_path, recipes):
+    """Build a PackageRegistry from ``{filename: recipe-dict}``.
+
+    Versions are written quoted so YAML keeps them as strings ("1.3" would
+    otherwise load as a float).
+    """
+    for filename, fields in recipes.items():
+        lines = [
+            f"package: {fields['package']}",
+            f"version: '{fields['version']}'",
+            f"url: https://example.invalid/{fields['package']}.tar.gz",
+        ]
+        if fields.get("dependencies"):
+            lines.append("dependencies: [%s]" % ", ".join(fields["dependencies"]))
+        (tmp_path / filename).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    registry = PackageRegistry()
+    registry.add_search_path(tmp_path)
+    registry.scan()
+    return registry
+
+
+@pytest.fixture
+def registry(tmp_path):
+    """app-1.0.0 depends on zlib; zlib exists at 1.2.13 and 1.3.0."""
+    return make_registry(tmp_path, {
+        "app.yaml": {"package": "app", "version": "1.0.0", "dependencies": ["zlib"]},
+        "zlib-1213.yaml": {"package": "zlib", "version": "1.2.13"},
+        "zlib-130.yaml": {"package": "zlib", "version": "1.3.0"},
+    })
+
+
+def versions_of(order):
+    return {recipe.name: recipe.version for recipe in order}
+
+
+# ── Version constraint handling ──────────────────────────────
+
+def test_explicit_version_survives_transitive_resolution(registry):
+    """An explicit request must win even when a dependency reached it first.
+
+    Regression: ``_collect`` memoized by name only, so resolving 'app' pulled
+    in the newest zlib and the later explicit 1.2.13 request hit the
+    ``if name in resolved`` early return and was silently dropped.
+    """
+    order = PackageResolver(registry).resolve(
+        [{"name": "app"}, {"name": "zlib", "version": "1.2.13"}]
+    )
+
+    assert versions_of(order)["zlib"] == "1.2.13"
+
+
+def test_resolution_is_independent_of_request_order(registry):
+    """The same request set must resolve identically regardless of ordering."""
+    requests = [{"name": "app"}, {"name": "zlib", "version": "1.2.13"}]
+
+    forward = versions_of(PackageResolver(registry).resolve(requests))
+    reverse = versions_of(PackageResolver(registry).resolve(list(reversed(requests))))
+
+    assert forward == reverse
+
+
+def test_conflicting_explicit_versions_raise(registry):
+    """Two mutually exclusive explicit versions must fail loudly."""
+    resolver = PackageResolver(registry)
+
+    with pytest.raises(ResolveError) as excinfo:
+        resolver.resolve(
+            [{"name": "zlib", "version": "1.3.0"}, {"name": "zlib", "version": "1.2.13"}]
+        )
+
+    message = str(excinfo.value)
+    assert "zlib" in message
+    assert "1.3.0" in message and "1.2.13" in message
+
+
+def test_repeated_identical_version_is_not_a_conflict(registry):
+    """Requesting the same version twice is harmless, not an error."""
+    order = PackageResolver(registry).resolve(
+        [{"name": "zlib", "version": "1.2.13"}, {"name": "zlib", "version": "1.2.13"}]
+    )
+
+    assert versions_of(order) == {"zlib": "1.2.13"}
+
+
+def test_unconstrained_request_still_selects_latest(registry):
+    """Existing behaviour: no version specified means newest available."""
+    order = PackageResolver(registry).resolve([{"name": "zlib"}])
+
+    assert versions_of(order)["zlib"] == "1.3.0"
+
+
+def test_explicit_version_applies_to_transitive_use(registry):
+    """A pin on a package reached only transitively is still honoured."""
+    order = PackageResolver(registry).resolve(
+        [{"name": "zlib", "version": "1.2.13"}, {"name": "app"}]
+    )
+
+    resolved = versions_of(order)
+    assert resolved["zlib"] == "1.2.13"
+    assert resolved["app"] == "1.0.0"
+
+
+# ── Pre-existing behaviour that must not regress ─────────────
+
+def test_build_order_places_dependencies_first(registry):
+    order = [recipe.name for recipe in PackageResolver(registry).resolve([{"name": "app"}])]
+
+    assert order.index("zlib") < order.index("app")
+
+
+def test_unknown_package_raises(registry):
+    with pytest.raises(ResolveError, match="not found in registry"):
+        PackageResolver(registry).resolve([{"name": "nonexistent"}])
+
+
+def test_unknown_version_of_known_package_raises(registry):
+    with pytest.raises(ResolveError, match="not found in registry"):
+        PackageResolver(registry).resolve([{"name": "zlib", "version": "9.9.9"}])
+
+
+def test_dependency_cycle_raises(tmp_path):
+    registry = make_registry(tmp_path, {
+        "a.yaml": {"package": "a", "version": "1.0.0", "dependencies": ["b"]},
+        "b.yaml": {"package": "b", "version": "1.0.0", "dependencies": ["a"]},
+    })
+
+    with pytest.raises(ResolveError, match="cycle"):
+        PackageResolver(registry).resolve([{"name": "a"}])
+
+
+def test_resolve_single_is_unaffected(registry):
+    recipe = PackageResolver(registry).resolve_single("zlib", "1.2.13")
+
+    assert recipe.version == "1.2.13"


### PR DESCRIPTION
## The problem

`PackageResolver` silently resolves packages to the wrong version.

`_collect()` memoizes purely by package name, so whichever traversal reaches a package first fixes its version for the entire resolution:

```python
if name in resolved:
    return
...
for dep_name in recipe.dependencies:
    self._collect(dep_name, None, resolved, graph)   # version always dropped
```

Three consequences, none of which produce a warning:

1. **An explicit version request is discarded** if a dependency already pulled the package in — the request hits the `if name in resolved` early return.
2. **Transitive dependencies are always collected with `version=None`**, and `PackageRegistry.get(name, None)` returns the *newest* entry in the registry.
3. **Two different versions of the same package** select one arbitrarily instead of reporting the conflict.

Reproduced against `master` (`b4b2ccc`) with a registry holding `app-1.0.0` (depends on `zlib`), `zlib-1.2.13`, and `zlib-1.3.0`:

| Request | Expected | Actual on master |
|---|---|---|
| `app`, then `zlib==1.2.13` | zlib 1.2.13 | **zlib 1.3.0** |
| `zlib==1.2.13`, then `app` | zlib 1.2.13 | zlib 1.2.13 |
| `zlib==1.3.0` + `zlib==1.2.13` | error | **zlib 1.3.0, no error** |

The same request set resolves differently depending on the order it is written in. For a tool whose stated purpose is reproducible embedded builds, silently building against the wrong dependency version is a correctness bug.

## The approach

Collect explicit version pins **before** walking the graph, then consult that map during traversal. Doing it up front is what makes the result order-independent — otherwise the first traversal to reach a package fixes its version and a pin appearing later in the list is swallowed by the memoization.

- `_collect_pins()` builds `{name: version}` from the request list and raises `ResolveError` naming the package and both versions when one package is requested at two different versions.
- `_collect()` takes the pin map instead of a single version and looks up `pins.get(name)`, so a pin applies wherever the package is reached, including transitively.

`ebuild/core/graph.py` is deliberately untouched — it already carries merged work (#36 deterministic topological sort, #52 O(1) lookups) and the cycle-detection path is unchanged.

Recipe `dependencies` are plain names with no version specifiers, so there is no per-dependency constraint to honour. This change is limited to versions the caller requests explicitly; adding constraint syntax to the recipe format would be a separate, larger change.

## Testing

New `tests/unit/test_resolver.py` — 11 cases. `ebuild/packages/` had no test coverage at all before this.

The three bug cases were written first and confirmed failing against unmodified `resolver.py`:

```
FAILED tests/unit/test_resolver.py::test_explicit_version_survives_transitive_resolution
   AssertionError: assert '1.3.0' == '1.2.13'
FAILED tests/unit/test_resolver.py::test_resolution_is_independent_of_request_order
   {'zlib': '1.3.0'} != {'zlib': '1.2.13'}
FAILED tests/unit/test_resolver.py::test_conflicting_explicit_versions_raise
   Failed: DID NOT RAISE ResolveError
3 failed, 8 passed
```

The remaining 8 cases pass both before and after — they guard existing behaviour (latest-version default, build ordering, unknown package, unknown version, cycle detection, `resolve_single`) so the fix cannot regress it.

After the change:

- `pytest tests/unit/` → **25 passed**
- `pytest` (full suite) → **109 passed** (98 before, +11 new)
- `ruff check ... --select=E,F,W --ignore=E501`, exactly as CI invokes it → **All checks passed**

## Considerations and limitations

**Test placement.** These went in `tests/unit/` rather than `tests/ebuild/` because the CI unit-test step runs `tests/unit/`. No workflow references `tests/ebuild/` at all.

**Two CI problems found while validating this, not addressed here** — happy to open a separate PR if useful:

1. `.github/workflows/ci.yml` triggers on `branches: [main, develop]` for push and `[main]` for pull_request, but the default branch is **`master`**. It is the only workflow that runs pytest on a pull request, so **no PR to this repo currently runs the Python test suite**. That is also why the badge in the README tracks a workflow that has not run.
2. That same workflow runs `pip install -r requirements.txt`, and there is no `requirements.txt` at the repo root (only `core/eboot/` and `layers/eosuite/` have one). The step has no `continue-on-error`, so it would fail the job if it ever ran.

**Behaviour change.** Requesting two incompatible versions now raises instead of silently picking one. That is the intended fix, but it will surface as a new error in any project that was previously relying on the silent behaviour — arguably a good thing, since such a project was not building what it asked for.

**Pre-existing, untouched:** `pytest.ini` lists `cross_repo` and `qemu` twice in its markers block.
