### PR TITLE
fix(ebuild): give each target its own object files

### DIFF
--- a/ebuild/build/ninja_backend.py
+++ b/ebuild/build/ninja_backend.py
@@ -52,6 +52,22 @@ class NinjaBackend:
         self._write_ninja()
         self._write_compile_commands()
 
+    def _object_path(self, target, src: str) -> Path:
+        """Object file path for *src* as compiled by *target*.
+
+        Object paths are namespaced by target name. Two targets may legitimately
+        list the same source: a library and a test binary sharing a helper, or
+        one source built twice with different defines. Each needs its own
+        object, because each compiles with its own cflags. Keying only on the
+        source made both targets claim one output, which ninja rejects with
+        "multiple rules generate ...".
+
+        Example:
+            >>> backend._object_path(target, "src/main.c")   # target.name == "app"
+            PosixPath('_build/obj/app/src/main.o')
+        """
+        return (self.build_dir / "obj" / target.name / src).with_suffix(".o")
+
     def _write_ninja(self) -> None:
         """Write the build.ninja file."""
         ninja_path = self.build_dir / "build.ninja"
@@ -101,7 +117,7 @@ class NinjaBackend:
 
             obj_files = []
             for src in target.sources:
-                obj = str(Path(self.build_dir / src).with_suffix(".o"))
+                obj = str(self._object_path(target, src))
                 obj_files.append(obj)
                 lines.append(
                     f"build {obj}: cc {src}"
@@ -181,9 +197,13 @@ class NinjaBackend:
 
             flags_str = f" {' '.join(cflags)}" if cflags else ""
             for src in target.sources:
+                # A source shared by two targets yields two entries, which the
+                # compilation database format allows. The -o keeps them
+                # distinguishable, and matches what ninja actually runs.
+                obj = self._object_path(target, src)
                 commands.append({
                     "directory": source_dir,
-                    "command": f"{self.toolchain.cc}{flags_str} -c {src}",
+                    "command": f"{self.toolchain.cc}{flags_str} -c {src} -o {obj}",
                     "file": src,
                 })
 

--- a/tests/unit/test_ninja_backend.py
+++ b/tests/unit/test_ninja_backend.py
@@ -10,6 +10,8 @@ options and dependencies.
 
 from pathlib import Path
 import json
+import subprocess
+import sys
 import pytest
 
 from ebuild.build.ninja_backend import NinjaBackend, PackagePaths
@@ -159,3 +161,138 @@ class TestNinjaBackend:
         assert "libmylib.a" in ninja_content
         assert "-lz" in ninja_content
         assert "-O3" in ninja_content
+
+    def test_shared_source_gets_one_object_per_target(self, tmp_path):
+        """A source used by two targets must compile to two distinct objects.
+
+        Keying object paths on the source alone makes both targets claim the
+        same output, which ninja rejects outright, and silently drops one
+        target's cflags.
+        """
+        lib_target = TargetConfig(
+            name="util",
+            target_type="static_library",
+            sources=["src/util.c"],
+            defines=["BUILD_LIB=1"],
+        )
+        app_target = TargetConfig(
+            name="app",
+            target_type="executable",
+            sources=["src/main.c", "src/util.c"],
+            defines=["BUILD_APP=1"],
+        )
+        config = ProjectConfig(
+            name="shared_source",
+            version="1.0.0",
+            targets=[lib_target, app_target],
+            source_dir=tmp_path,
+        )
+        toolchain = ResolvedToolchain(cc="gcc", cxx="g++", ar="ar")
+
+        build_dir = tmp_path / "_build"
+        NinjaBackend(config, build_dir, toolchain).generate()
+
+        ninja_content = (build_dir / "build.ninja").read_text(encoding="utf-8")
+
+        # Split on the rule separator rather than the first colon: on Windows
+        # the object path starts with a drive letter.
+        outputs = [
+            line[len("build "):].split(": cc ", 1)[0].strip()
+            for line in ninja_content.splitlines()
+            if line.startswith("build ") and ": cc " in line
+        ]
+        assert len(outputs) == 3, f"expected 3 compile edges, got {outputs}"
+        assert len(set(outputs)) == 3, f"duplicate object outputs: {outputs}"
+
+        # Each target's defines must survive onto its own object.
+        assert "-DBUILD_LIB=1" in ninja_content
+        assert "-DBUILD_APP=1" in ninja_content
+
+    def test_shared_source_manifest_is_valid_ninja(self, tmp_path, monkeypatch):
+        """The generated manifest must load in real ninja, not just look right.
+
+        Ninja treats two edges producing one output as an error, so this is
+        the check that actually proves the generated build is usable.
+
+        The build directory is relative and the working directory is the
+        project root, mirroring how ``ebuild build`` invokes the backend.
+        """
+        pytest.importorskip("ninja", reason="ninja package not installed")
+
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (src_dir / "util.c").write_text("int util_answer(void) { return 42; }\n")
+        (src_dir / "main.c").write_text(
+            "int util_answer(void);\nint main(void) { return util_answer() == 42 ? 0 : 1; }\n"
+        )
+
+        config = ProjectConfig(
+            name="shared_source",
+            version="1.0.0",
+            targets=[
+                TargetConfig(
+                    name="util",
+                    target_type="static_library",
+                    sources=["src/util.c"],
+                    defines=["BUILD_LIB=1"],
+                ),
+                TargetConfig(
+                    name="app",
+                    target_type="executable",
+                    sources=["src/main.c", "src/util.c"],
+                    defines=["BUILD_APP=1"],
+                ),
+            ],
+            source_dir=tmp_path,
+        )
+
+        monkeypatch.chdir(tmp_path)
+        build_dir = Path("_build")
+        NinjaBackend(config, build_dir, ResolvedToolchain(cc="gcc", cxx="g++", ar="ar")).generate()
+
+        # -n parses and validates the manifest without running the compiler,
+        # so this test needs no toolchain on the machine running it.
+        result = subprocess.run(
+            [sys.executable, "-m", "ninja", "-f", str(build_dir / "build.ninja"), "-n"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"ninja rejected the generated manifest:\n{result.stdout}\n{result.stderr}"
+        )
+
+    def test_compile_commands_distinguishes_shared_source_entries(self, tmp_path):
+        """compile_commands.json entries for a shared source must differ.
+
+        Two targets compiling one file legitimately produce two entries; each
+        needs its own -o so a consumer can tell them apart.
+        """
+        config = ProjectConfig(
+            name="shared_source",
+            version="1.0.0",
+            targets=[
+                TargetConfig(
+                    name="util",
+                    target_type="static_library",
+                    sources=["src/util.c"],
+                    defines=["BUILD_LIB=1"],
+                ),
+                TargetConfig(
+                    name="app",
+                    target_type="executable",
+                    sources=["src/util.c"],
+                    defines=["BUILD_APP=1"],
+                ),
+            ],
+            source_dir=tmp_path,
+        )
+
+        build_dir = tmp_path / "_build"
+        NinjaBackend(config, build_dir, ResolvedToolchain(cc="gcc", cxx="g++", ar="ar")).generate()
+
+        cc_data = json.loads((build_dir / "compile_commands.json").read_text(encoding="utf-8"))
+        shared = [e for e in cc_data if e["file"] == "src/util.c"]
+        assert len(shared) == 2
+        assert shared[0]["command"] != shared[1]["command"]
+        assert all(" -o " in e["command"] for e in shared)


### PR DESCRIPTION
## Summary

If two targets in a `build.yaml` list the same source file, `ebuild build`
generates a `build.ninja` that ninja refuses to load:

```
ninja: error: build.ninja:32: multiple rules generate _build/src/util.o
```

Nothing compiles. This PR gives each target its own object directory.

## What is wrong

`ninja_backend.py` named object files from the source path alone:

```python
obj = str(Path(self.build_dir / src).with_suffix(".o"))
```

Nothing in that path identifies the target doing the compiling. So this
perfectly ordinary config:

```yaml
targets:
  - name: util
    type: static_library
    sources: ["src/util.c"]
    defines: ["BUILD_LIB=1"]

  - name: app
    type: executable
    sources: ["src/main.c", "src/util.c"]
    defines: ["BUILD_APP=1"]
```

produced two build edges writing to one file, carrying contradictory flags:

```
   build.yaml                     generated build.ninja
   ──────────                     ─────────────────────

   target: util                   build _build/src/util.o: cc src/util.c
     src/util.c   ──────────────►   cflags = -DBUILD_LIB=1
                                                │
                                                │  same output path
   target: app                                  │  different flags
     src/main.c   ──────────────► build _build/src/main.o: cc src/main.c
     src/util.c   ──────────────► build _build/src/util.o: cc src/util.c
                                    cflags = -DBUILD_APP=1
                                          ▲
                                          └── ninja: multiple rules
                                              generate this output
```

## Why it matters

Three reasons this is worth fixing rather than documenting as a limitation.

**It is a hard failure, not a degradation.** Ninja has treated duplicate
outputs as an error since 1.9 (`dupbuild=err`), and `pyproject.toml` pins
`ninja>=1.11`. The build stops before a single file is compiled.

**The error blames the wrong thing.** It surfaces from ninja, not from
ebuild, so it reads as a broken tool rather than as a problem with your
`build.yaml`. There is no hint about which target pair caused it.

**Sharing a source between targets is normal.** A library and a test binary
using one helper, or a single source compiled twice with different `-D`
defines, are both routine. Even if ninja had tolerated the duplicate, the
generation was already wrong: one object node can hold only one `cflags`
line, so one target's flags would silently win.

No example under `examples/` currently shares a source across targets, which
is why this has not come up before.

## How it is fixed

Object files move under `obj/<target>/`. This is what CMake, Meson and Bazel
all do, for exactly this reason:

```
   before                              after
   ──────                              ─────
   _build/                             _build/
   ├── src/                            ├── obj/
   │   ├── main.o                      │   ├── util/
   │   └── util.o  ◄── contested       │   │   └── src/util.o   -DBUILD_LIB=1
   ├── libutil.a                       │   └── app/
   └── app                             │       ├── src/main.o   -DBUILD_APP=1
                                       │       └── src/util.o   -DBUILD_APP=1
                                       ├── libutil.a
                                       └── app
```

A single helper, `_object_path(target, src)`, is now the only place an object
gets named. Both the `build.ninja` writer and the `compile_commands.json`
writer call it, so the two can never disagree.

Target output names (`_build/app`, `_build/libutil.a`) are unchanged, so
nothing downstream of the build moves.

`compile_commands.json` had the same root cause. A shared source produced two
entries whose `command` strings were byte for byte identical, leaving a
consumer no way to tell them apart. The compilation database format
explicitly allows one file to appear more than once; what was missing is the
`-o` that distinguishes the entries. Each now carries it, which also makes
the recorded command match what ninja actually runs.

## Testing

Three regression tests were added to `tests/unit/test_ninja_backend.py`,
which is the file CI already runs. Per `TESTING.md`, each was confirmed to
fail before the fix:

| Test | Failure before the fix |
|---|---|
| `test_shared_source_gets_one_object_per_target` | `duplicate object outputs: [util.o, main.o, util.o]` |
| `test_shared_source_manifest_is_valid_ninja` | `ninja: error: multiple rules generate _build/src/util.o` |
| `test_compile_commands_distinguishes_shared_source_entries` | the two entries' commands are identical |

The middle test is the one that actually proves the build works. It shells
out to real ninja with `-n`, which parses and validates the manifest without
running the compiler. That means it needs no toolchain on the runner, so it
works across the whole ubuntu / macos / windows matrix.

Full suite: **101 passed.** The three pre-existing tests in that file assert
on flags rather than object paths, and pass unchanged.

End to end, on a project sharing a source between two targets:

```
$ python -m ninja -f _build/build.ninja -n
[1/5] CC _build/obj/util/src/util.o
[2/5] CC _build/obj/app/src/main.o
[3/5] CC _build/obj/app/src/util.o
[4/5] AR _build/libutil.a
[5/5] LINK _build/app
```

Before the fix, the same project exited 1 without planning a single edge.

## Limitations, and things I noticed but left alone

**I did not run a real compile.** `ninja -n` proves the manifest is valid and
the edges are planned. It does not prove gcc accepts the flags. There was no
C toolchain on the machine I worked on. CI's matrix covers the real compile.

**Stale objects are not cleaned up.** An existing `_build` directory keeps
its old `_build/src/*.o` files, which are now orphaned. They are harmless,
and `ebuild clean` removes them.

**Executables still do not link `shared_library` dependencies.** The
dependency walk in `_write_ninja` collects archives only from
`static_library` targets, so an executable that depends on a `shared_library`
links against nothing. Separate bug, left out to keep this reviewable. Happy
to open it as its own PR.

**Windows absolute build paths produce an invalid manifest.** If `build_dir`
is absolute, ninja parses the drive-letter colon in `C:\...` as the rule
separator and reports `expected build command name`. The CLI always passes a
relative build dir, so this is not hit in practice, but the generator should
escape `:` as `$:`. Also separate, also happy to follow up.

## Pre-submission checklist

- [x] All existing tests pass (101 passed)
- [x] New tests added, each confirmed to fail without the change
- [x] No new lint findings (the two flake8 warnings in this file predate the change)
- [x] Commit signed off (DCO)
