### PR TITLE
fix(build): eliminate shell command injection in _create_initramfs()

### DIFF
--- a/ebuild/cli/integration.py
+++ b/ebuild/cli/integration.py
@@ -17,7 +17,10 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional
-
+import gzip
+import shutil
+import subprocess
+from pathlib import Path
 import click
 
 from ebuild.cli.logger import Logger
@@ -194,8 +197,29 @@ def _build_rootfs(build_dir: Path, libs: List[Path], trigger: str,
 def _create_initramfs(rootfs: Path, build_dir: Path) -> Path:
     """Create a cpio+gzip initramfs from the rootfs."""
     initramfs = build_dir / "initramfs.cpio.gz"
-    cmd = f"cd {rootfs} && find . | cpio -o -H newc 2>/dev/null | gzip > {initramfs}"
-    subprocess.run(cmd, shell=True, capture_output=True)
+    cpio_path = build_dir / "initramfs.cpio"
+
+    find_proc = subprocess.run(
+        ["find", "."],
+        cwd=rootfs,
+        capture_output=True,
+        check=True,
+    )
+
+    with open(cpio_path, "wb") as cpio_out:
+        subprocess.run(
+            ["cpio", "-o", "-H", "newc"],
+            input=find_proc.stdout,
+            stdout=cpio_out,
+            stderr=subprocess.DEVNULL,
+            cwd=rootfs,
+            check=True,
+        )
+
+    with open(cpio_path, "rb") as f_in, gzip.open(initramfs, "wb") as f_out:
+        shutil.copyfileobj(f_in, f_out)
+
+    cpio_path.unlink(missing_ok=True)
     return initramfs
 
 


### PR DESCRIPTION
## Problem
_create_initramfs() builds a shell command string via f-string interpolation of `rootfs` and `build_dir` Path objects, then executes it with subprocess.run(cmd, shell=True). Since these paths are not escaped, any shell metacharacter in either path (spaces, `;`, backticks, `$()`, `|`) is interpreted by the shell rather than treated as literal text. Depending on how build_dir/rootfs are derived (CLI flags, project config, CI-generated paths), this ranges from a build breakage to arbitrary command execution.

Separately, capture_output=True is used without check=True or a returncode check, so a partial cpio/gzip failure can silently produce a corrupt or empty initramfs that still passes the caller's initramfs.exists() check.

## Fix
- Remove shell=True entirely; run `find` and `cpio` as list-form subprocess calls with cwd=rootfs instead of `cd {rootfs} &&`.
- Replace the shelled-out `gzip` with Python's stdlib gzip module.
- Add check=True to both subprocess calls so failures raise instead of producing a corrupt artifact.

## Testing
- Built initramfs from a rootfs path containing a space and a rootfs path containing `; touch /tmp/pwned` — before the fix, the latter created /tmp/pwned; after the fix, both paths are treated as literal directory names and no command executes.
- Verified initramfs.cpio.gz content is identical (same file list, same cpio format) to the shell=True version for a normal path.

## Summary

<!-- Brief description of what this PR does. -->


## Type of Change

<!-- Check all that apply -->

- [ ] eat — New feature
- [ ] ix — Bug fix
- [ ] docs — Documentation only
- [ ] style — Formatting, no code change
- [ ] 
efactor — Code restructuring without behavior change
- [ ] 	est — Add or fix tests
- [ ] uild — Build system or dependency changes
- [ ] ci — CI/CD pipeline changes
- [ ] perf — Performance improvement

## Changes

<!-- List each change made in this PR -->

- 
- 

## Testing

<!-- How was this tested? Which test suites were run? -->

- [ ] Unit tests pass (ctest --test-dir build --output-on-failure)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] New tests added for new functionality

## Pre-Submission Checklist

- [ ] Code compiles without warnings (-Wall -Wextra -Werror for C)
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Documentation updated if API changed
- [ ] Commit messages follow <type>(<scope>): <description> convention
- [ ] Branch is rebased on latest master

## Related Issues

<!-- Reference related issues: Closes #XX, Fixes #YY -->


## Screenshots / Logs

<!-- If applicable, add screenshots or relevant log output -->


## Additional Notes

<!-- Any other context reviewers should know -->

