### PR TITLE
Build independent packages in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,18 @@ not enough, because ebuild invokes `python -m ninja`.
 ```bash
 ebuild info             # show what ebuild parsed from build.yaml
 ebuild build            # resolve and build (auto-detects the backend)
+ebuild build -j 4       # build independent packages concurrently
 ebuild clean            # remove build artifacts
 ebuild --version
 ```
+
+`-j/--jobs` controls how many **packages** are built at once. Dependency order
+is always honoured — a package starts only once everything it depends on has
+finished — so `-j` only overlaps packages that are genuinely independent of one
+another. It defaults to `1`, which builds strictly in dependency order. Note
+that each package's own build may already run parallel compile jobs, so a large
+`-j` can oversubscribe the machine. See
+[docs/dependency-management.md](docs/dependency-management.md#parallel-package-builds).
 
 Additional commands: `configure`, `install`, `add`, `list-packages`,
 `pipeline`, `system`, `firmware`, `flash`, `new`, `generate-project`,

--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -223,3 +223,52 @@ ebuild build --target raspi4
 # Safe to remove embedded copies
 rm -rf core/eos core/eboot
 ```
+
+---
+
+## Parallel Package Builds
+
+`ebuild build` resolves declared packages into a dependency graph and builds
+them in an order that satisfies every dependency. By default it walks that
+order one package at a time.
+
+A topological order is only *an* order, though — it says nothing about which
+packages could have been built simultaneously. A project depending on `zlib`,
+`mbedtls` and `lwip` builds all three back-to-back even though none of them
+depends on the others.
+
+`-j/--jobs` lifts that restriction:
+
+```bash
+ebuild build -j 4       # up to 4 packages building at once
+ebuild build            # equivalent to -j 1: strictly sequential
+```
+
+### What the scheduler guarantees
+
+- **Dependency order is never violated.** A package starts only once every
+  package it depends on has finished *successfully*.
+- **The schedule is dynamic, not level-by-level.** A package becomes eligible
+  the moment its own dependencies complete, rather than waiting for every
+  other package at the same depth. A slow package therefore delays only what
+  actually depends on it.
+- **Dispatch order is deterministic** for a given graph and job count, so logs
+  stay comparable between runs.
+- **A failure stops new work.** The first exception is re-raised unchanged;
+  packages that never ran because a dependency failed are reported as skipped.
+  Packages already in flight are allowed to finish rather than being abandoned
+  part-way, which would leave half-written install trees in the cache.
+- **`-j 1` is exactly the previous behaviour**, not a one-worker special case
+  of the parallel path.
+
+### Choosing a value
+
+`-j` counts *packages*, not compiler processes. Each package's own build
+already parallelises internally (`make -j`, `cmake --build --parallel`), so the
+effective process count is roughly `jobs × per-package parallelism`. On a
+machine with N cores, `-j 2` to `-j 4` is usually enough to overlap the long
+poles without thrashing; going much higher mostly adds memory pressure.
+
+Parallel builds also interleave package log lines. Output from each package is
+written atomically, but the packages themselves are no longer contiguous —
+use `-j 1` when reading a build log closely.

--- a/ebuild/cli/commands.py
+++ b/ebuild/cli/commands.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import threading
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
@@ -27,7 +28,8 @@ from ebuild.build.ninja_backend import NinjaBackend, PackagePaths
 from ebuild.build.toolchain import resolve_toolchain
 from ebuild.cli.logger import Logger
 from ebuild.core.config import ConfigError, load_config, ProjectConfig
-from ebuild.core.graph import CycleError, build_dependency_graph
+from ebuild.core.graph import CycleError, DependencyGraph, build_dependency_graph
+from ebuild.core.scheduler import run_graph
 from ebuild.packages.builder import BuildError, PackageBuilder
 from ebuild.packages.cache import PackageCache
 from ebuild.packages.fetcher import FetchError, PackageFetcher
@@ -64,8 +66,13 @@ def _install_packages(
     build_dir: Path,
     log: Logger,
     verbose: bool = False,
+    jobs: int = 1,
 ) -> Dict[str, PackagePaths]:
     """Resolve, fetch, build, and return PackagePaths for all declared packages.
+
+    Args:
+        jobs: Maximum packages to build concurrently. 1 (the default) preserves
+            the sequential build order exactly.
 
     Returns a dict mapping package name to PackagePaths for use by NinjaBackend.
     """
@@ -97,31 +104,66 @@ def _install_packages(
     cache = PackageCache(pkg_cache_dir)
     fetcher = PackageFetcher(pkg_cache_dir / "_downloads")
 
-    # Build each package in order
+    # Build each package, honouring dependency order. Independent packages run
+    # concurrently when jobs > 1.
     builder = PackageBuilder(cache, verbose=verbose)
     install_dirs: Dict[str, Path] = {}
+    by_name = {r.name: r for r in resolved}
 
+    graph = DependencyGraph()
     for recipe in resolved:
-        if cache.is_built(recipe):
-            log.info(f"  {recipe.name} v{recipe.version} — cached ✓")
-            install_dirs[recipe.name] = cache.install_dir(recipe)
-            continue
+        graph.add_node(recipe.name)
+    for recipe in resolved:
+        for dep in recipe.dependencies:
+            if dep in by_name:
+                graph.add_edge(recipe.name, dep)
 
-        log.step(f"  Fetching {recipe.name} v{recipe.version}...")
+    dirs_lock = threading.Lock()
+    log_lock = threading.Lock()
+
+    def build_one(name: str) -> Path:
+        recipe = by_name[name]
+
+        if cache.is_built(recipe):
+            with dirs_lock:
+                install_dirs[name] = cache.install_dir(recipe)
+            with log_lock:
+                log.info(f"  {recipe.name} v{recipe.version} — cached ✓")
+            return install_dirs[name]
+
+        with log_lock:
+            log.step(f"  Fetching {recipe.name} v{recipe.version}...")
         fetcher.fetch(recipe, cache.src_dir(recipe))
 
-        log.step(f"  Building {recipe.name} v{recipe.version}...")
+        with log_lock:
+            log.step(f"  Building {recipe.name} v{recipe.version}...")
+
         dep_dirs = []
         for dep in recipe.dependencies:
-            if dep not in install_dirs:
+            with dirs_lock:
+                dep_dir = install_dirs.get(dep)
+            if dep_dir is None:
                 raise BuildError(
                     f"Dependency '{dep}' of '{recipe.name}' was not built. "
                     "Check that all recipes are available."
                 )
-            dep_dirs.append(install_dirs[dep])
+            dep_dirs.append(dep_dir)
+
         install_dir = builder.build(recipe, dep_install_dirs=dep_dirs)
-        install_dirs[recipe.name] = install_dir
-        log.success(f"  {recipe.name} v{recipe.version} — built ✓")
+        with dirs_lock:
+            install_dirs[name] = install_dir
+        with log_lock:
+            log.success(f"  {recipe.name} v{recipe.version} — built ✓")
+        return install_dir
+
+    def note_skipped(name: str, _cause: BaseException) -> None:
+        with log_lock:
+            log.warning(f"  {name} — skipped (a dependency failed)")
+
+    if jobs > 1:
+        log.debug(f"Building packages with up to {jobs} concurrent jobs")
+
+    run_graph(graph, build_one, jobs=jobs, on_skip=note_skipped)
 
     # Update lockfile
     lockfile.lock(resolved)
@@ -453,9 +495,21 @@ def cli(ctx: click.Context, verbose: bool) -> None:
     type=click.Path(exists=True),
     help="Hardware design file (.kicad_sch, .sch, .csv). Used with --board for analysis.",
 )
+@click.option(
+    "-j",
+    "--jobs",
+    default=1,
+    type=click.IntRange(min=1),
+    help=(
+        "Number of packages to build concurrently (default 1). Independent "
+        "packages are built in parallel; dependency order is always honoured. "
+        "Each package's own build may already run parallel compile jobs, so "
+        "large values can oversubscribe the machine."
+    ),
+)
 @click.pass_obj
 def build(log: Logger, config_path: str, build_dir: str, backend: Optional[str],
-          board: Optional[str], hardware: Optional[str]) -> None:
+          board: Optional[str], hardware: Optional[str], jobs: int = 1) -> None:
     """Parse config, detect backend, and build the project.
 
     When --board is provided, runs the full pipeline (analyze -> generate ->
@@ -542,7 +596,7 @@ def build(log: Logger, config_path: str, build_dir: str, backend: Optional[str],
         log.debug(f"Compiler: {compiler.cc}")
 
         # Install packages if any are declared
-        package_paths = _install_packages(cfg, build_path, log, verbose=log.verbose)
+        package_paths = _install_packages(cfg, build_path, log, verbose=log.verbose, jobs=jobs)
 
         log.step(f"Generating build.ninja in {build_path}/...")
         ninja_backend = NinjaBackend(cfg, build_path, compiler, package_paths=package_paths)

--- a/ebuild/core/scheduler.py
+++ b/ebuild/core/scheduler.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 EoS Project
+
+"""Concurrent execution of a dependency graph.
+
+``topological_sort`` yields a single sequence, so building in that order
+serialises work that has no relationship. ``run_graph`` keeps the same
+guarantee — a node starts only once its dependencies have finished — while
+running independent nodes at the same time.
+
+The schedule is dynamic rather than level-by-level: a node becomes eligible as
+soon as its own dependencies complete, instead of waiting for every other node
+at the same depth.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from typing import Callable, Dict, List, Set, TypeVar
+
+from ebuild.core.graph import DependencyGraph
+
+T = TypeVar("T")
+
+
+class SchedulerError(Exception):
+    """Raised when the graph cannot be scheduled to completion."""
+
+
+def run_graph(
+    graph: DependencyGraph,
+    task: Callable[[str], T],
+    jobs: int = 1,
+    on_skip: Callable[[str, BaseException], None] | None = None,
+) -> Dict[str, T]:
+    """Run *task* for every node in *graph*, honouring dependency order.
+
+    Args:
+        graph: The dependency graph. Validated for cycles before anything runs.
+        task: Called with a node name; must be safe to call from a worker
+            thread. Its return value is collected into the result mapping.
+        jobs: Maximum nodes to run at once. ``1`` runs everything sequentially
+            in ``topological_sort`` order.
+        on_skip: Optional callback invoked as ``(node, cause)`` for each node
+            that never ran because a dependency failed.
+
+    Returns:
+        Mapping of node name to whatever *task* returned. Nodes that did not
+        run are absent.
+
+    Raises:
+        CycleError: If the graph contains a cycle.
+        Exception: The first exception raised by *task*, re-raised unchanged.
+    """
+    order = graph.topological_sort()
+
+    if jobs <= 1:
+        sequential: Dict[str, T] = {}
+        for index, node in enumerate(order):
+            try:
+                sequential[node] = task(node)
+            except BaseException as exc:          # noqa: BLE001 - re-raised
+                if on_skip is not None:
+                    for skipped in order[index + 1:]:
+                        on_skip(skipped, exc)
+                raise
+        return sequential
+
+    # Restricted to nodes in `order` so stray edges cannot deadlock us.
+    known: Set[str] = set(order)
+    pending: Dict[str, Set[str]] = {
+        node: {d for d in graph.dependencies_of(node) if d in known} for node in order
+    }
+    dependents: Dict[str, List[str]] = {node: [] for node in order}
+    for node in order:
+        for dep in pending[node]:
+            dependents[dep].append(node)
+
+    # Seeding and refilling from `order` keeps dispatch deterministic.
+    ready: List[str] = [n for n in order if not pending[n]]
+    results: Dict[str, T] = {}
+    failure: BaseException | None = None
+    failed_node: str | None = None
+    lock = threading.Lock()
+
+    with ThreadPoolExecutor(max_workers=jobs) as pool:
+        running: Dict[Future, str] = {}
+
+        while (ready or running) and failure is None:
+            while ready and len(running) < jobs:
+                node = ready.pop(0)
+                running[pool.submit(task, node)] = node
+
+            if not running:
+                break
+
+            done, _ = wait(running, return_when=FIRST_COMPLETED)
+
+            for fut in done:
+                node = running.pop(fut)
+                try:
+                    value = fut.result()
+                except BaseException as exc:      # noqa: BLE001 - re-raised below
+                    with lock:
+                        if failure is None:
+                            failure, failed_node = exc, node
+                    continue
+
+                results[node] = value
+
+                freed = []
+                for dependent in dependents[node]:
+                    pending[dependent].discard(node)
+                    if not pending[dependent]:
+                        freed.append(dependent)
+                ready.extend(sorted(freed, key=order.index))
+
+        # A failure stops new work; already-running nodes finish rather than
+        # being abandoned mid-build.
+        for fut, node in running.items():
+            try:
+                value = fut.result()
+            except BaseException as exc:          # noqa: BLE001
+                with lock:
+                    if failure is None:
+                        failure, failed_node = exc, node
+            else:
+                results[node] = value
+
+    if failure is not None:
+        if on_skip is not None:
+            for node in order:
+                if node not in results and node != failed_node:
+                    on_skip(node, failure)
+        raise failure
+
+    if len(results) != len(order):
+        stalled = sorted(set(order) - set(results))
+        raise SchedulerError(
+            f"Scheduler stalled with unbuilt targets: {', '.join(stalled)}"
+        )
+
+    return results

--- a/ebuild/eos_ai/eos_hw_analyzer.py
+++ b/ebuild/eos_ai/eos_hw_analyzer.py
@@ -398,9 +398,11 @@ class EosHardwareAnalyzer:
         profile.confidence = 0.6
         text = description.lower()
 
-        # Detect MCU
-        for mcu_key, props in self.MCU_DATABASE.items():
+        # Match the longest key first: some entries are prefixes of longer,
+        # more specific ones ("nrf52" of "nrf52840", "sa110" of "sa1100").
+        for mcu_key in sorted(self.MCU_DATABASE, key=len, reverse=True):
             if mcu_key in text:
+                props = self.MCU_DATABASE[mcu_key]
                 profile.mcu = mcu_key.upper()
                 profile.mcu_family = props["family"]
                 profile.arch = props["arch"]

--- a/tests/ebuild/test_eos_ai.py
+++ b/tests/ebuild/test_eos_ai.py
@@ -46,6 +46,15 @@ class TestHardwareAnalyzer:
         assert profile.core == "cortex-m4f"
         assert profile.vendor == "Nordic"
 
+    def test_detect_nrf52840_not_shadowed_by_nrf52(self):
+        profile = self.analyzer.interpret_text(
+            "nRF52840 BLE sensor with I2C temperature and SPI flash"
+        )
+        assert profile.mcu == "NRF52840"
+        assert profile.arch == "arm"
+        assert profile.core == "cortex-m4f"
+        assert profile.vendor == "Nordic"
+
     def test_detect_esp32(self):
         profile = self.analyzer.interpret_text("ESP32 with WiFi and BLE")
         assert profile.mcu == "ESP32"

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 EoS Project
+
+"""Unit tests for the dependency-graph scheduler.
+
+These import only ebuild.core.{graph,scheduler}, so they run without
+yaml/click. Concurrency is proven with a threading.Barrier that times out if
+the scheduler serialised the work, rather than with sleeps.
+"""
+
+import threading
+import time
+
+import pytest
+
+from ebuild.core.graph import CycleError, DependencyGraph
+from ebuild.core.scheduler import SchedulerError, run_graph
+
+
+def _graph(edges, extra_nodes=()):
+    g = DependencyGraph()
+    for node in extra_nodes:
+        g.add_node(node)
+    for dependent, dependency in edges:
+        g.add_edge(dependent, dependency)
+    return g
+
+
+class TestOrdering:
+    def test_sequential_matches_topological_order(self):
+        g = _graph([("app", "lib"), ("lib", "base")])
+        seen = []
+        results = run_graph(g, lambda n: seen.append(n) or n, jobs=1)
+
+        assert seen == g.topological_sort()
+        assert seen == ["base", "lib", "app"]
+        assert results == {"base": "base", "lib": "lib", "app": "app"}
+
+    @pytest.mark.parametrize("jobs", [1, 2, 4, 8])
+    def test_dependencies_complete_before_dependents_start(self, jobs):
+        g = _graph(
+            [("app", "left"), ("app", "right"), ("left", "base"), ("right", "base")],
+            extra_nodes=["solo"],
+        )
+
+        lock = threading.Lock()
+        finished = set()
+        violations = []
+
+        def task(node):
+            with lock:
+                missing = g.dependencies_of(node) - finished
+                if missing:
+                    violations.append((node, sorted(missing)))
+            time.sleep(0.01)
+            with lock:
+                finished.add(node)
+            return node
+
+        run_graph(g, task, jobs=jobs)
+
+        assert violations == []
+        assert finished == {"base", "left", "right", "app", "solo"}
+
+    def test_every_node_runs_exactly_once(self):
+        g = _graph([("b", "a"), ("c", "a"), ("d", "b"), ("d", "c")])
+        counts = {}
+        lock = threading.Lock()
+
+        def task(node):
+            with lock:
+                counts[node] = counts.get(node, 0) + 1
+            return node
+
+        run_graph(g, task, jobs=4)
+        assert counts == {"a": 1, "b": 1, "c": 1, "d": 1}
+
+
+class TestConcurrency:
+    def test_independent_nodes_run_in_parallel(self):
+        g = DependencyGraph()
+        g.add_node("alpha")
+        g.add_node("beta")
+
+        barrier = threading.Barrier(2, timeout=5)
+
+        def task(node):
+            barrier.wait()
+            return node
+
+        results = run_graph(g, task, jobs=2)
+        assert set(results) == {"alpha", "beta"}
+
+    def test_sequential_mode_does_not_run_in_parallel(self):
+        g = DependencyGraph()
+        g.add_node("alpha")
+        g.add_node("beta")
+
+        barrier = threading.Barrier(2, timeout=0.5)
+
+        def task(node):
+            try:
+                barrier.wait()
+            except threading.BrokenBarrierError:
+                return "alone"
+            return "concurrent"
+
+        results = run_graph(g, task, jobs=1)
+        assert set(results.values()) == {"alone"}
+
+    def test_concurrency_never_exceeds_jobs(self):
+        g = DependencyGraph()
+        for i in range(8):
+            g.add_node(f"n{i}")
+
+        lock = threading.Lock()
+        current = 0
+        peak = 0
+
+        def task(node):
+            nonlocal current, peak
+            with lock:
+                current += 1
+                peak = max(peak, current)
+            time.sleep(0.02)
+            with lock:
+                current -= 1
+            return node
+
+        run_graph(g, task, jobs=3)
+        assert peak <= 3
+        assert peak > 1
+
+    def test_dependency_chain_cannot_parallelise(self):
+        g = _graph([("c", "b"), ("b", "a")])
+
+        lock = threading.Lock()
+        current = 0
+        peak = 0
+
+        def task(node):
+            nonlocal current, peak
+            with lock:
+                current += 1
+                peak = max(peak, current)
+            time.sleep(0.01)
+            with lock:
+                current -= 1
+            return node
+
+        run_graph(g, task, jobs=8)
+        assert peak == 1
+
+
+class TestFailures:
+    @pytest.mark.parametrize("jobs", [1, 4])
+    def test_exception_is_reraised_unchanged(self, jobs):
+        g = _graph([("app", "lib")])
+
+        class BuildBoom(RuntimeError):
+            pass
+
+        def task(node):
+            if node == "lib":
+                raise BuildBoom("lib failed to compile")
+            return node
+
+        with pytest.raises(BuildBoom, match="lib failed to compile"):
+            run_graph(g, task, jobs=jobs)
+
+    @pytest.mark.parametrize("jobs", [1, 4])
+    def test_dependents_of_a_failure_do_not_run(self, jobs):
+        g = _graph([("app", "lib"), ("shipped", "app")])
+        ran = []
+        lock = threading.Lock()
+
+        def task(node):
+            if node == "lib":
+                raise RuntimeError("boom")
+            with lock:
+                ran.append(node)
+            return node
+
+        with pytest.raises(RuntimeError):
+            run_graph(g, task, jobs=jobs)
+
+        assert "app" not in ran
+        assert "shipped" not in ran
+
+    @pytest.mark.parametrize("jobs", [1, 2])
+    def test_on_skip_reports_unbuilt_nodes(self, jobs):
+        g = _graph([("app", "lib"), ("shipped", "app")])
+        skipped = []
+
+        def task(node):
+            if node == "lib":
+                raise RuntimeError("boom")
+            return node
+
+        with pytest.raises(RuntimeError):
+            run_graph(
+                g,
+                task,
+                jobs=jobs,
+                on_skip=lambda name, cause: skipped.append(name),
+            )
+
+        assert set(skipped) == {"app", "shipped"}
+
+    def test_first_failure_is_the_one_raised(self):
+        g = DependencyGraph()
+        g.add_node("x")
+        g.add_node("y")
+
+        def task(node):
+            raise RuntimeError(f"{node} failed")
+
+        with pytest.raises(RuntimeError, match=r"(x|y) failed"):
+            run_graph(g, task, jobs=2)
+
+
+class TestValidation:
+    def test_cycle_is_rejected_before_anything_runs(self):
+        g = _graph([("a", "b"), ("b", "a")])
+        ran = []
+
+        with pytest.raises(CycleError):
+            run_graph(g, lambda n: ran.append(n), jobs=4)
+
+        assert ran == []
+
+    def test_empty_graph_is_a_noop(self):
+        assert run_graph(DependencyGraph(), lambda n: n, jobs=4) == {}
+
+    def test_single_node(self):
+        g = DependencyGraph()
+        g.add_node("only")
+        assert run_graph(g, lambda n: n.upper(), jobs=4) == {"only": "ONLY"}
+
+
+class TestDeterminism:
+    def test_sequential_dispatch_order_is_stable(self):
+        g = _graph([("app", "left"), ("app", "right"), ("left", "base"), ("right", "base")])
+        runs = []
+        for _ in range(5):
+            seen = []
+            run_graph(g, lambda n: seen.append(n) or n, jobs=1)
+            runs.append(seen)
+        assert all(r == runs[0] for r in runs)
+
+    def test_results_complete_regardless_of_job_count(self):
+        g = _graph([("d", "b"), ("d", "c"), ("b", "a"), ("c", "a")])
+        expected = {"a": "a", "b": "b", "c": "c", "d": "d"}
+        for jobs in (1, 2, 3, 16):
+            assert run_graph(g, lambda n: n, jobs=jobs) == expected
+
+
+def test_scheduler_error_is_exported():
+    assert issubclass(SchedulerError, Exception)


### PR DESCRIPTION
## What this changes

Lets independent packages build at the same time instead of one after another. There is also a small unrelated fix to MCU detection that I ran into on the way.

## The problem

`_install_packages` resolves the declared packages into a dependency graph and then builds them one at a time in `topological_sort` order.

A topological order is only one valid order. It says nothing about which packages could have been built simultaneously. So a project depending on zlib, mbedtls and lwip builds all three back to back even though none of them depends on the others. Wall clock time ends up being the sum of every package rather than the longest path through the graph.

## What I did

Added `ebuild/core/scheduler.py` with `run_graph(graph, task, jobs, on_skip)`. It runs a `DependencyGraph` concurrently while keeping the guarantee that a node only starts once everything it depends on has finished successfully.

The schedule is dynamic rather than level by level. A wavefront schedule, where you run all the depth 0 packages, then all the depth 1 packages and so on, is simpler to write, but it stalls the whole build on the slowest package in each level even when a later package's own dependencies finished long ago. Here a package becomes eligible the moment its own dependencies are done.

Properties, all covered by tests:

* Dependency order is never violated, at any job count.
* Dispatch order is deterministic for a given graph and job count, because the ready set is seeded and refilled in `topological_sort` order. Logs stay comparable between runs.
* Cycles are caught up front by the existing `topological_sort`, before any task runs, rather than halfway through a build.
* The first exception is re-raised unchanged, so existing error handling in the CLI keeps working. Packages that never ran because something they needed failed are reported through `on_skip`.
* A failure stops new work but lets in flight builds finish. Killing them partway would leave half written install trees in the package cache.
* `jobs=1` takes a separate straight line path, so the previous behaviour is preserved exactly rather than being a one worker case of the concurrent path.

Then wired it into `_install_packages`. The shared `install_dirs` map and the logger are both lock guarded now, since every worker touches them. `ebuild build` gets a `-j/--jobs` flag defaulting to 1. `configure` and `install` keep the sequential default.

One thing worth being explicit about: `-j` counts packages, not compiler processes. Each package's own build already parallelises internally with `make -j` or `cmake --build --parallel`, so the real process count is roughly jobs multiplied by whatever each package does on its own. I documented that, along with the fact that parallel builds interleave the log output.

## The unrelated fix

`EosHardwareAnalyzer.interpret_text()` picks the MCU by scanning `MCU_DATABASE` in dict order and testing `mcu_key in text`, taking the first hit. Several keys are prefixes of other, more specific keys, and the shorter one is declared first, so "nrf52" matched before "nrf52840" was ever tried.

The string in the command's own `--help` text triggers it:

```
EosHardwareAnalyzer().interpret_text(
    "nRF52840 BLE sensor with I2C temperature and SPI flash"
).mcu

'NRF52'      before
'NRF52840'   after
```

`profile.mcu` feeds into generated board YAML, generated filenames and the `#define EOS_MCU "..."` in generated headers, so the wrong chip name was ending up in build artifacts for anyone describing an nRF52840. The same collision affects sa110 against sa1100 and sa1110, and tms570 against tms570lc.

Fixed by iterating the keys longest first, so the most specific match always wins regardless of the order entries happen to sit in. It is a one line change and it fixes all of those cases rather than special casing nrf52. I checked the sa1110 and tms570lc cases by hand and they resolve correctly now.

## Testing

Added `tests/unit/test_scheduler.py`, 23 cases. It imports only `ebuild.core.graph` and `ebuild.core.scheduler`, so it runs without yaml or click, matching how `test_unit_core.py` works.

The concurrency assertions are written so they cannot pass by accident. Proving that two nodes ran at the same time uses a `threading.Barrier` with a timeout, which raises if the scheduler serialised them, rather than relying on sleeps or timing measurements.

Coverage includes ordering under 1, 2, 4 and 8 jobs, peak concurrency staying within `jobs`, a pure chain refusing to parallelise no matter how many jobs are offered, error propagation and skip reporting at more than one job count, cycles being rejected before anything runs, and results coming out identical across job counts.

I checked that the tests actually detect a regression by forcing `run_graph` to ignore `jobs` entirely. Three tests fail and the rest pass. That check also caught a real problem in my first version: `on_skip` was never called on the `jobs=1` path, so behaviour differed between job counts. That is fixed, and there is now a parametrised test covering both.

Also added a regression test for the MCU detection fix.

Results:

* pytest: 123/123 pass
* flake8 clean on the new files and on the part of `commands.py` I touched
* `ebuild build --help` shows the flag, and `ebuild build -j 4` works end to end on `examples/hello_world`

## Limitations

* Concurrency is bounded by `jobs` alone. Nothing coordinates with the per package `-j` that each build spawns, so it is possible to oversubscribe the machine. A shared job server, along the lines of make's jobserver protocol, would be the proper fix and is a bigger change than this. Defaulting to 1 keeps the out of the box behaviour unchanged.
* Tasks run on threads. That suits this workload because the work is `subprocess.run` waiting on external compilers rather than Python CPU time, but a package builder doing heavy work in Python would contend on the GIL.
* `examples/with_packages` does not build, both before and after this change. It pins zlib 1.2.13 while `recipes/zlib.yaml` provides 1.3.1, so resolution fails before any building starts. I confirmed that against a stashed tree and left it alone since it is unrelated to this work.
