### PR TITLE
test(packages): make the fetcher's fixture archive reproducible

### DIFF
--- a/tests/ebuild/test_package_fetcher.py
+++ b/tests/ebuild/test_package_fetcher.py
@@ -10,6 +10,7 @@ extracted from the wrong archive carries the wrong marker.
 """
 
 import hashlib
+import gzip
 import io
 import tarfile
 
@@ -57,14 +58,28 @@ def make_recipe(name, version="2.9.3", url=None, checksum=None):
 
 
 def targz_bytes(marker):
-    """A valid .tar.gz containing a single file whose body is *marker*."""
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+    """A valid .tar.gz containing a single file whose body is *marker*.
+
+    Byte-for-byte reproducible. Both the tar header and the gzip header carry a
+    timestamp, and the defaults are "now" -- so two calls with the same marker
+    produced different bytes, and therefore different SHA-256, if they landed on
+    opposite sides of a second boundary. That made every checksum derived from
+    this helper a coin flip: the digest computed for the recipe had to match the
+    bytes handed out by fake_download later. It held on fast Linux runners and
+    failed on Windows. Pinning both timestamps to 0 removes the race.
+    """
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as tar:
         data = marker.encode("utf-8")
         info = tarfile.TarInfo("pkg/marker.txt")
         info.size = len(data)
+        info.mtime = 0
         tar.addfile(info, io.BytesIO(data))
-    return buf.getvalue()
+
+    out = io.BytesIO()
+    with gzip.GzipFile(fileobj=out, mode="wb", mtime=0) as gz:
+        gz.write(raw.getvalue())
+    return out.getvalue()
 
 
 def sha256_of(data):


### PR DESCRIPTION
**Rebased onto current master and reduced to one change.** The supply-chain content this PR opened with — the four corrected pins, the checksum-format validation, and `fetch()` refusing to download without a digest — is now on master, applied there directly rather than by merging this branch. All of it verified identical, so it is dropped from here.

What remains is the one piece master does not have.

## The fixture archive is not reproducible

`targz_bytes()` builds its `.tar.gz` with default timestamps, so two calls with the same marker return different bytes:

```python
a = sha256(targz_bytes("x")); sleep(1.1)
b = sha256(targz_bytes("x"))
a == b   # False on master, True with this patch
```

Every checksum in this module is derived from the helper and then has to match the bytes `fake_download` hands out later, so the suite is a coin flip on timing — it holds on fast Linux runners and fails on Windows.

Two timestamps default to "now": the tar member header and the gzip header. Writing the tar uncompressed with `info.mtime = 0` and compressing through `GzipFile(mtime=0)` pins both.

16/16 in this module pass, and the digest is now stable across a second boundary.

> The CI failure previously on this branch was master's, not this PR's — `import ebuild.cli.commands` raises `NameError: name 're' is not defined`, so nine test modules cannot be collected. #97 fixes that.
