### PR TITLE
Fix/fix graph node names that can become unterminated

### DIFF
--- a/core/eos/core/src/graph.c
+++ b/core/eos/core/src/graph.c
@@ -21,6 +21,7 @@ EosResult eos_graph_add_node(EosGraph *g, const char *name, EosNodeType type,
     int id = g->node_count;
     EosNode *n = &g->nodes[id];
     strncpy(n->name, name, EOS_MAX_NAME - 1);
+    n->name[EOS_MAX_NAME-1] = '\0';
     n->type = type;
     n->build_type = build_type;
     n->status = EOS_NODE_PENDING;

--- a/core/eos/tests/test_graph.c
+++ b/core/eos/tests/test_graph.c
@@ -52,6 +52,39 @@ static void test_graph_add_nodes(void) {
 
     ASSERT(g.node_count == 3, "graph has 3 nodes");
 }
+static void test_graph_max_length_node_name(void) {
+    printf("test_graph_max_length_node_name:\n");
+
+    EosGraph g;
+    eos_graph_init(&g);
+
+    char name[EOS_MAX_NAME];
+
+    /* Create a name that fills the buffer except for the null terminator. */
+    memset(name, 'A', EOS_MAX_NAME - 1);
+    name[EOS_MAX_NAME - 1] = '\0';
+
+    int id;
+    EosResult r = eos_graph_add_node(
+        &g,
+        name,
+        EOS_NODE_PACKAGE,
+        EOS_BUILD_CMAKE,
+        &id
+    );
+
+    ASSERT(r == EOS_OK, "maximum-length node name can be added");
+
+    ASSERT(
+        g.nodes[id].name[EOS_MAX_NAME - 1] == '\0',
+        "node name is null terminated"
+    );
+
+    ASSERT(
+        eos_graph_find_node(&g, name) == id,
+        "maximum-length node name can be found"
+    );
+}
 
 static void test_graph_find_node(void) {
     printf("test_graph_find_node:\n");
@@ -168,6 +201,7 @@ int main(void) {
     test_graph_init();
     test_graph_add_nodes();
     test_graph_find_node();
+    test_graph_max_length_node_name();
     test_topological_sort_linear();
     test_topological_sort_diamond();
     test_cycle_detection();

--- a/core/eos/tests/test_graph.c
+++ b/core/eos/tests/test_graph.c
@@ -64,6 +64,13 @@ static void test_graph_max_length_node_name(void) {
     memset(name, 'A', EOS_MAX_NAME - 1);
     name[EOS_MAX_NAME - 1] = '\0';
 
+    /*
+     * Fill the destination with non-zero data so the test can detect
+     * a missing null terminator even though eos_graph_init() zeroes
+     * the graph initially.
+     */
+    memset(g.nodes[0].name, 'X', EOS_MAX_NAME);
+
     int id;
     EosResult r = eos_graph_add_node(
         &g,
@@ -85,7 +92,6 @@ static void test_graph_max_length_node_name(void) {
         "maximum-length node name can be found"
     );
 }
-
 static void test_graph_find_node(void) {
     printf("test_graph_find_node:\n");
     EosGraph g;


### PR DESCRIPTION
## Issue

Graph node names are stored in a fixed-size character buffer. When a node name reaches the maximum supported length, `strncpy()` may copy the requested number of characters without adding a null terminator.

This can leave `EosNode.name` unterminated even though it is later used as a C string by functions such as `strcmp()` and logging/output code. This can result in incorrect string handling and potentially undefined behavior.

## Proposed Approach

Ensure that the destination buffer is explicitly null terminated after copying the node name.

The implementation uses:

```c
strncpy(n->name, name, EOS_MAX_NAME - 1);
n->name[EOS_MAX_NAME - 1] = '\0';
```

A regression test was also added for a node name that uses the maximum number of characters available before the null terminator.

The test pre-fills the destination buffer with non-zero data before adding the node. This ensures the test can detect a missing null terminator rather than accidentally passing because the graph was initially zero-initialized.

## Testing

Added `test_graph_max_length_node_name()` to the graph test suite.

The test verifies that:

- A maximum-length node name can be added successfully.
- The stored node name is null terminated.
- The maximum-length node can be found using `eos_graph_find_node()`.

The existing graph tests for initialization, node creation, node lookup, topological sorting, cycle detection, and independent nodes are also retained.

## Validation

The test specifically exercises the boundary condition where the node name contains `EOS_MAX_NAME - 1` characters.

The destination buffer is deliberately filled with non-zero bytes before adding the node. This allows the regression test to detect a missing null terminator if the explicit termination is removed from the implementation.

## Considerations and Limitations

This change does not alter the existing public API or the fixed-size node-name representation.

Names longer than `EOS_MAX_NAME - 1` characters continue to be truncated to fit the destination buffer. The important difference is that the resulting stored name is guaranteed to be null terminated.

The change is intentionally limited to node-name handling and its regression test.