### PR TITLE
config: reject a non-list packages section instead of dropping it

### DIFF
--- a/ebuild/core/config.py
+++ b/ebuild/core/config.py
@@ -281,18 +281,25 @@ def load_config(config_path: str | Path) -> ProjectConfig:
 
     # --- packages section (optional, Phase 2) ---
     packages: List[PackageDep] = []
-    raw_packages = raw.get("packages", [])
-
-    if isinstance(raw_packages, list):
-        for p in raw_packages:
-            if isinstance(p, dict):
-                pkg_name = p.get("name", "")
-                pkg_version = p.get("version")
-
-                if pkg_name:
-                    packages.append(
-                        PackageDep(name=pkg_name, version=pkg_version)
-                    )
+    if "packages" in raw:
+        raw_packages = raw["packages"]
+        if not isinstance(raw_packages, list):
+            raise ConfigError(
+                "'packages' must be a list of package definitions."
+            )
+        for pkg in raw_packages:
+            if not isinstance(pkg, dict):
+                raise ConfigError(
+                    "Invalid package definition: expected a YAML mapping, "
+                    f"got {type(pkg).__name__}."
+                )
+            pkg_name = pkg.get("name", "")
+            pkg_version = pkg.get("version")
+            if not pkg_name:
+                raise ConfigError("Package definition must have a 'name' field.")
+            if pkg_version is not None and not isinstance(pkg_version, str):
+                pkg_version = str(pkg_version)
+            packages.append(PackageDep(name=pkg_name, version=pkg_version))
 
     return ProjectConfig(
         name=project_name,

--- a/tests/ebuild/test_config_validation.py
+++ b/tests/ebuild/test_config_validation.py
@@ -96,3 +96,69 @@ def test_toolchain_mapping_is_parsed(tmp_path):
     assert config.toolchain.sysroot == "/opt/arm-none-eabi"
     assert config.toolchain.extra_cflags == ["-mcpu=cortex-m4"]
     assert config.toolchain.extra_ldflags == ["--specs=nosys.specs"]
+
+
+@pytest.mark.parametrize("invalid_packages", [
+    {"name": "zlib", "version": "1.2.13"},
+    "zlib",
+    42,
+])
+def test_packages_must_be_a_list(tmp_path, invalid_packages):
+    path = write_config(
+        tmp_path,
+        {"project": {"name": "demo"}, "packages": invalid_packages},
+    )
+
+    with pytest.raises(ConfigError, match="'packages' must be a list"):
+        load_config(path)
+
+
+@pytest.mark.parametrize("invalid_item", ["zlib", 42, None])
+def test_package_definition_must_be_mapping(tmp_path, invalid_item):
+    path = write_config(
+        tmp_path,
+        {"project": {"name": "demo"}, "packages": [invalid_item]},
+    )
+
+    with pytest.raises(ConfigError, match="expected a YAML mapping"):
+        load_config(path)
+
+
+def test_package_definition_requires_name(tmp_path):
+    path = write_config(
+        tmp_path,
+        {
+            "project": {"name": "demo"},
+            "packages": [{"version": "1.2.13"}],
+        },
+    )
+
+    with pytest.raises(ConfigError, match="must have a 'name'"):
+        load_config(path)
+
+
+def test_packages_list_is_parsed(tmp_path):
+    path = write_config(
+        tmp_path,
+        {
+            "project": {"name": "demo"},
+            "packages": [
+                {"name": "zlib", "version": "1.2.13"},
+                {"name": "mbedtls"},
+            ],
+        },
+    )
+
+    config = load_config(path)
+
+    assert len(config.packages) == 2
+    assert config.packages[0].name == "zlib"
+    assert config.packages[0].version == "1.2.13"
+    assert config.packages[1].name == "mbedtls"
+    assert config.packages[1].version is None
+
+
+def test_omitted_packages_is_empty(tmp_path):
+    path = write_config(tmp_path, {"project": {"name": "demo"}})
+    config = load_config(path)
+    assert config.packages == []


### PR DESCRIPTION
Contribution after reviewing the project: `load_config()` already rejects a non-list `targets:` / `toolchain` / `backend_config`, but a `packages:` that is a mapping or scalar was dropped with no error. A common YAML mistake (`packages: {name: zlib, version: "1.2.13"}` instead of a list) therefore produced a project with zero package deps.

## Issue

`ebuild/core/config.py` treated `packages:` as optional and only walked it when `isinstance(raw_packages, list)`. Anything else — including a mapping, which is what you get if the `-` is omitted — was silently ignored. Individual list items that were not mappings, and mappings without `name`, were also skipped.

## Approach

If `packages` is present, require a list of mappings with a `name` field (same shape as `targets`). Non-string YAML versions (e.g. `version: 1.0` parsed as a float) are coerced to `str` so `PackageDep.version` stays a string. Omitted `packages` still means no dependencies.

## Testing

Added cases in `tests/ebuild/test_config_validation.py`:
- mapping / string / int `packages:` raises `ConfigError`
- list items that are not mappings raise
- a mapping without `name` raises
- a valid two-package list still parses
- omitted `packages` is empty

Validated by reading the parser and matching the existing target/toolchain tests. I did not run the full pytest suite in this environment (no local checkout of the repo).

## Limitations

Does not invent a shorthand `packages: [zlib]` form. Does not validate that `version` is a useful version string, only that it can be stored as `str`. Duplicate package names are still allowed.