### PR TITLE
fix(deps): resolve sibling eBoot as well as eboot

### DIFF
--- a/ebuild/deps/manager.py
+++ b/ebuild/deps/manager.py
@@ -14,7 +14,7 @@ import os
 import subprocess
 import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 
@@ -29,6 +29,12 @@ from ebuild.deps import (
 
 # Known repo names
 KNOWN_REPOS = ("eos", "eboot")
+
+# Sibling directory names. GitHub and local checkouts often use eBoot.
+SIBLING_DIR_NAMES: Dict[str, Tuple[str, ...]] = {
+    "eos": ("eos",),
+    "eboot": ("eboot", "eBoot"),
+}
 
 # Environment variable names for path overrides
 ENV_PATH_VARS = {
@@ -46,7 +52,7 @@ class DepsManager:
     2. Environment variables ``EBUILD_EOS_PATH`` / ``EBUILD_EBOOT_PATH``
     3. ``~/.ebuild/config.yaml`` custom ``path:`` override
     4. ``~/.ebuild/repos/<name>/`` (cached git clone)
-    5. Sibling directory ``../<name>/`` (workspace layout)
+    5. Sibling directory ``../<name>/`` (workspace layout; ``eboot`` also tries ``eBoot``)
     6. Embedded ``core/<name>/`` (legacy fallback — prints deprecation warning)
     """
 
@@ -204,11 +210,13 @@ class DepsManager:
         if cached.is_dir():
             return cached
 
-        # 5. Sibling directory
+        # 5. Sibling directory (try documented aliases; Linux is case-sensitive)
         if project_dir:
-            sibling = project_dir.parent / repo_name
-            if sibling.is_dir():
-                return sibling
+            names = SIBLING_DIR_NAMES.get(repo_name, (repo_name,))
+            for name in names:
+                sibling = project_dir.parent / name
+                if sibling.is_dir():
+                    return sibling
 
         # 6. Legacy embedded core/<name>/ (deprecation warning)
         if project_dir:

--- a/tests/ebuild/conftest.py
+++ b/tests/ebuild/conftest.py
@@ -17,8 +17,20 @@ import pytest
 # ── Repo roots (available to all tests via conftest) ─────────
 # tests/ebuild/conftest.py → parent = tests/ebuild/ → parent = tests/ → parent = repo root
 EBUILD_ROOT = Path(__file__).resolve().parent.parent.parent
-EBOOT_ROOT = EBUILD_ROOT.parent / "eboot"
-EOS_ROOT = EBUILD_ROOT.parent / "eos"
+
+
+def _sibling_repo(*names: str) -> Path:
+    """First existing sibling dir, preferring the first name if none exist."""
+    parent = EBUILD_ROOT.parent
+    for name in names:
+        candidate = parent / name
+        if candidate.is_dir():
+            return candidate
+    return parent / names[0]
+
+
+EBOOT_ROOT = _sibling_repo("eboot", "eBoot")
+EOS_ROOT = _sibling_repo("eos")
 
 
 def _module_available(name: str) -> bool:

--- a/tests/ebuild/test_deps_manager.py
+++ b/tests/ebuild/test_deps_manager.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 EoS Project
+
+"""Host tests for DepsManager sibling path resolution."""
+
+from pathlib import Path
+
+import pytest
+
+from ebuild.deps.manager import DepsManager, SIBLING_DIR_NAMES
+
+
+@pytest.fixture
+def isolated_deps(tmp_path, monkeypatch):
+    """Keep get_repo_path off the real ~/.ebuild cache and config."""
+    home = tmp_path / "ebuild-home"
+    repos = home / "repos"
+    config = home / "config.yaml"
+    monkeypatch.setattr("ebuild.deps.manager.ensure_ebuild_home", lambda: home)
+    monkeypatch.setattr("ebuild.deps.manager.EBUILD_CONFIG_PATH", config)
+    monkeypatch.setenv("EBUILD_REPOS_DIR", str(repos))
+    monkeypatch.delenv("EBUILD_EOS_PATH", raising=False)
+    monkeypatch.delenv("EBUILD_EBOOT_PATH", raising=False)
+    home.mkdir()
+    repos.mkdir()
+    return tmp_path
+
+
+def _case_sensitive_is_dir(self: Path) -> bool:
+    """Treat directory names as case-sensitive, as Linux does."""
+    try:
+        names = {child.name for child in self.parent.iterdir()}
+    except OSError:
+        return False
+    return self.name in names
+
+
+def test_eboot_aliases_include_github_casing():
+    assert SIBLING_DIR_NAMES["eboot"] == ("eboot", "eBoot")
+
+
+def test_sibling_eboot_resolves_camel_case(isolated_deps, monkeypatch):
+    workspace = isolated_deps / "ws"
+    project = workspace / "ebuild"
+    camel = workspace / "eBoot"
+    project.mkdir(parents=True)
+    camel.mkdir()
+    monkeypatch.setattr(Path, "is_dir", _case_sensitive_is_dir)
+
+    resolved = DepsManager().get_repo_path("eboot", project_dir=project)
+
+    assert resolved is not None
+    assert resolved.name == "eBoot"
+
+
+def test_sibling_eboot_still_resolves_lowercase(isolated_deps, monkeypatch):
+    workspace = isolated_deps / "ws"
+    project = workspace / "ebuild"
+    lower = workspace / "eboot"
+    project.mkdir(parents=True)
+    lower.mkdir()
+    monkeypatch.setattr(Path, "is_dir", _case_sensitive_is_dir)
+
+    resolved = DepsManager().get_repo_path("eboot", project_dir=project)
+
+    assert resolved is not None
+    assert resolved.name == "eboot"
+
+
+def test_sibling_eboot_missing_returns_none(isolated_deps, monkeypatch):
+    workspace = isolated_deps / "ws"
+    project = workspace / "ebuild"
+    project.mkdir(parents=True)
+    monkeypatch.setattr(Path, "is_dir", _case_sensitive_is_dir)
+
+    resolved = DepsManager().get_repo_path("eboot", project_dir=project)
+
+    assert resolved is None


### PR DESCRIPTION
## Summary

Sibling repo lookup used only `../eboot`. The public repo and many local trees are named `eBoot`, so Linux CI and a case-sensitive workspace would not find the bootloader. This PR tries both names in the dependency manager and the pytest fixture.

This addresses:

- **Issue:** case-sensitive miss of the eBoot sibling
- **Approach:** alias list `eboot`, `eBoot` on the sibling step only
- **Testing:** host tests with a case-sensitive `is_dir` mock; 4 passed
- **Limits:** sibling step only; does not change cache, env, or CLI overrides

## Type of Change

- [ ] feat — New feature
- [x] fix — Bug fix
- [ ] docs — Documentation only
- [ ] style — Formatting, no code change
- [ ] refactor — Code restructuring without behavior change
- [x] test — Add or fix tests
- [ ] build — Build system or dependency changes
- [ ] ci — CI/CD pipeline changes
- [ ] perf — Performance improvement

## Changes

- Resolve `"eboot"` from `../eboot` or `../eBoot`
- Point the eboot pytest fixture at whichever sibling exists
- Add tests for camel-case, lowercase, and missing siblings

## Testing

- [x] Unit tests pass (`python -m pytest tests/ebuild/test_deps_manager.py -v`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [x] New tests added for new functionality

## Pre-Submission Checklist

- [ ] Code compiles without warnings (`-Wall -Wextra -Werror` for C)
- [ ] All existing tests pass
- [x] New tests added for new functionality
- [ ] Documentation updated if API changed
- [x] Commit messages follow `<type>(<scope>): <description>` convention
- [ ] Branch is rebased on latest master

## Related Issues

None. Found while reviewing workspace layout against GitHub’s `eBoot` repo name.

## Screenshots / Logs

```
4 passed in 0.07s
```

## Additional Notes

- Does not alter `ebuild/core/eboot` (deprecated).
- Windows already treated `eboot` and `eBoot` as the same folder; this is for Linux and CI.
- Integration CLI already had a local case fallback; the shared `DepsManager` path did not.