### PR TITLE
fix(ninja): link shared libraries through the link_shared rule

### DIFF
--- a/ebuild/build/ninja_backend.py
+++ b/ebuild/build/ninja_backend.py
@@ -123,15 +123,24 @@ class NinjaBackend:
             "  command = $cc $ldflags $in -o $out $libs",
             "  description = LINK $out",
             "",
-            "rule link_shared",
-            "  command = $cc -shared $ldflags $in -o $out $libs",
-            "  description = LINK_SHARED $out",
-            "",
             "rule ar_rule",
             "  command = $ar rcs $out $in",
             "  description = AR $out",
             "",
         ]
+
+        # The flag that turns a link into a shared object is spelled
+        # differently on Darwin. Emit the rule only when something needs it,
+        # so a purely static project's build.ninja does not carry a rule for
+        # a link it never performs.
+        shared_flag = "-dynamiclib" if sys.platform == "darwin" else "-shared"
+        if any(t.target_type == "shared_library" for t in self.config.targets):
+            lines += [
+                "rule link_shared",
+                f"  command = $cc {shared_flag} $ldflags $in -o $out $libs",
+                "  description = LINK_SHARED $out",
+                "",
+            ]
 
         toolchain_ldflags = self._get_toolchain_ldflags()
 
@@ -190,11 +199,10 @@ class NinjaBackend:
                 if target.target_type == "static_library":
                     lines.append(f"build {out}: ar_rule {' '.join(obj_files)}")
                 else:
-                    # Shared libraries need the platform's "build a shared
-                    # object" flag and the same -L/-l wiring executables get,
-                    # neither of which the generic `link` rule provides.
+                    # link_shared carries the platform's "build a shared
+                    # object" flag; the -L/-l wiring is the same as for
+                    # executables and still goes through ldflags/libs.
                     ldflags = list(target.ldflags)
-                    ldflags.insert(0, "-dynamiclib" if sys.platform == "darwin" else "-shared")
                     libs = []
                     for pkg_name in target.uses:
                         pkg = self.package_paths.get(pkg_name)
@@ -204,7 +212,7 @@ class NinjaBackend:
                             for lib in pkg.libraries:
                                 libs.append(f"-l{lib}")
 
-                    lines.append(f"build {out}: link {' '.join(obj_files)}")
+                    lines.append(f"build {out}: link_shared {' '.join(obj_files)}")
                     if ldflags:
                         lines.append(f"  ldflags = {' '.join(ldflags)}")
                     if libs:

--- a/tests/ebuild/test_ninja_backend.py
+++ b/tests/ebuild/test_ninja_backend.py
@@ -45,7 +45,9 @@ def test_shared_library_uses_shared_link_rule(tmp_path):
     NinjaBackend(config, tmp_path / "build", toolchain).generate()
 
     ninja_file = (tmp_path / "build" / "build.ninja").read_text(encoding="utf-8")
-    assert "rule link_shared\n  command = $cc -shared" in ninja_file
+    # Darwin spells the flag -dynamiclib; the CI matrix covers macos-13.
+    shared_flag = "-dynamiclib" if sys.platform == "darwin" else "-shared"
+    assert f"rule link_shared\n  command = $cc {shared_flag}" in ninja_file
     assert "build " in ninja_file
     assert ": link_shared " in ninja_file
 

--- a/tests/unit/test_ninja_backend.py
+++ b/tests/unit/test_ninja_backend.py
@@ -40,9 +40,10 @@ class TestNinjaBackendSharedLibrary(unittest.TestCase):
 
         shared_flag = "-dynamiclib" if sys.platform == "darwin" else "-shared"
         self.assertIn(shared_flag, ninja)
-        # It must use the `link` rule (compiler driver), not `ar_rule`.
+        # It must go through a compiler-driver link rule, not `ar_rule`.
         lib_line = next(line for line in ninja.splitlines() if "libmylib" in line and line.startswith("build"))
-        self.assertIn(": link ", lib_line)
+        self.assertNotIn(": ar_rule", lib_line)
+        self.assertIn(": link_shared ", lib_line)
 
     def test_shared_library_gets_lib_dirs_and_libs(self):
         target = TargetConfig(


### PR DESCRIPTION
Shared library support landed twice, in two shapes that don't agree, and the
halves were never reconciled.

`_write_ninja()` defines a `link_shared` rule:

```
rule link_shared
  command = $cc -shared $ldflags $in -o $out $libs
```

Nothing refers to it. The build statement for a `shared_library` target uses the
plain `link` rule and pushes the platform flag into that target's `ldflags`
instead:

```python
ldflags.insert(0, "-dynamiclib" if sys.platform == "darwin" else "-shared")
...
lines.append(f"build {out}: link {' '.join(obj_files)}")
```

So `link_shared` is dead code, and since it's emitted unconditionally its
hardcoded `-shared` shows up in the `build.ninja` of a project that builds
nothing but static archives.

Each half also brought its own test. `tests/ebuild/...::test_shared_library_uses_shared_link_rule`
expects `: link_shared `, `tests/unit/...::test_shared_library_gets_shared_flag`
expects `: link `, and `test_static_library_unaffected` expects no `-shared`
anywhere. On master all three fail, on every entry in the CI matrix:

```
FAILED tests/ebuild/test_ninja_backend.py::test_shared_library_uses_shared_link_rule
FAILED tests/unit/test_ninja_backend.py::...::test_shared_library_gets_shared_flag
FAILED tests/unit/test_ninja_backend.py::...::test_static_library_unaffected
3 failed, 198 passed, 1 skipped
```

I went with the rule rather than deleting it. It produces a correct
`LINK_SHARED` line in ninja's output instead of labelling a shared link `LINK`,
and holding the flag in the rule keeps it out of the ldflags of every target
that isn't a shared library. Two details the old rule got wrong, fixed on the
way: it's now emitted only when a `shared_library` target exists, and the flag
is the platform's spelling rather than a hardcoded `-shared`, since the matrix
includes `macos-13` where it's `-dynamiclib`.

Two test assertions move with it. `tests/unit` asserted `": link "`; the comment
above it says its purpose is that the target goes through a compiler driver
rather than `ar_rule`, so it now asserts exactly that. `tests/ebuild` hardcoded
`-shared`, which would have failed on the macOS runner as soon as the rule was
reached at all.

## Testing

macOS 15, Python 3.14.

```
$ python -m pytest tests/ -q
201 passed, 1 skipped
```

Reverting `ninja_backend.py` alone and keeping the tests reproduces the three
failures above, so the tests do exercise the change. `ldflags` for a shared
target now contains only what the target and its packages asked for; `-L`/`-l`
wiring is unchanged, and `test_shared_library_gets_lib_dirs_and_libs` still
covers it.

One caveat on the numbers: master doesn't import right now — `ebuild/build/dispatch.py`
has a `SyntaxError` and `NinjaBackend._object_path` is missing, which #78/#75
and #79 address. I ran the suite with those two applied locally to get a
baseline. This branch touches neither file, so it should merge in any order
relative to them.
