### PR TITLE
fix(integration): build initramfs without host cpio

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -11,13 +11,13 @@ Status is one of: `todo`, `in-progress`, `blocked`, `review`, `done`.
 
 | ID | Task | Owner | Mode | Status | Depends on |
 |----|------|-------|------|--------|------------|
-| —  | No active tasks. | — | — | — | — |
+| T-002 | Fix Windows Ninja test-target path parsing | backend | Maintenance | todo | none |
 
 ## Completed
 
 | ID | Task | Owner | Verified by | Evidence |
 |----|------|-------|-------------|----------|
-| —  | None yet. | — | — | — |
+| T-001 | Make initramfs creation portable and self-contained | backend | independent reviewer | Focused archive tests: **5 passed, 1 skipped** (symlink creation unavailable on this Windows host). Independent `bsdtar` extraction validated hard-link identity and payload. Full Python suite: **288 passed, 2 skipped, 1 unrelated failure** in the pre-existing Windows Ninja path assertion, recorded as T-002. QEMU boot was not run on Windows. |
 
 ---
 

--- a/ebuild/cli/integration.py
+++ b/ebuild/cli/integration.py
@@ -11,16 +11,15 @@ Provides CLI commands to:
 
 from __future__ import annotations
 
+import gzip
 import os
 import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional
-import gzip
-import shutil
-import subprocess
-from pathlib import Path
+
 import click
 
 from ebuild.cli.logger import Logger
@@ -195,42 +194,136 @@ def _build_rootfs(build_dir: Path, libs: List[Path], trigger: str,
     return rootfs
 
 
-def _create_initramfs(rootfs: Path, build_dir: Path) -> Path:
-    """Create a cpio+gzip initramfs from the rootfs.
+def _newc_padding(length: int) -> bytes:
+    """Return the zero padding needed to align *length* to four bytes."""
+    return b"\0" * (-length % 4)
 
-    Security note: this used to build a single shell string (``cd {rootfs}
-    && find . | cpio ... > {initramfs}``) and run it with ``shell=True``.
-    Both ``rootfs`` and ``build_dir`` ultimately come from the ``--build-dir``
-    CLI option, which click accepts as an unrestricted path -- a value like
-    ``/tmp/x; touch /tmp/pwned #`` was interpolated straight into the shell
-    string and executed. This rebuilds the same find | cpio | gzip pipeline
-    as three argv-list subprocesses connected by pipes, so no shell is ever
-    invoked and no part of the path can be interpreted as shell syntax.
+
+def _newc_mode(path: Path, metadata) -> int:
+    """Return a POSIX file type and mode suitable for a ``newc`` record.
+
+    Windows reports regular files as non-executable even when they are shell
+    scripts or cross-compiled ELF binaries. Use conservative archive defaults
+    there and restore the execute bits only when file contents identify an
+    executable format. POSIX hosts retain the source mode unchanged.
     """
+    mode = metadata.st_mode
+    if os.name != "nt":
+        return mode
+    if stat.S_ISDIR(mode):
+        return stat.S_IFDIR | 0o755
+    if stat.S_ISLNK(mode):
+        return stat.S_IFLNK | 0o777
+    if not stat.S_ISREG(mode):
+        return mode
+
+    permissions = 0o644 if mode & stat.S_IWRITE else 0o444
+    with path.open("rb") as source:
+        magic = source.read(4)
+    if magic.startswith(b"#!") or magic == b"\x7fELF":
+        permissions |= 0o111
+    return stat.S_IFREG | permissions
+
+
+def _write_newc_entry(
+    out, path: Path, name: str, metadata, inode: int, include_data: bool
+) -> None:
+    """Write one filesystem object as a ``newc`` cpio record."""
+    mode = _newc_mode(path, metadata)
+    inline_data = None
+
+    if stat.S_ISREG(mode):
+        file_size = metadata.st_size if include_data else 0
+    elif stat.S_ISLNK(mode):
+        inline_data = os.fsencode(os.readlink(path))
+        file_size = len(inline_data)
+    elif stat.S_ISDIR(mode):
+        file_size = 0
+    else:
+        raise ValueError(f"Unsupported initramfs file type: {path}")
+
+    encoded_name = os.fsencode(name) + b"\0"
+    fields = (
+        inode,
+        mode,
+        getattr(metadata, "st_uid", 0),
+        getattr(metadata, "st_gid", 0),
+        max(metadata.st_nlink, 1),
+        int(metadata.st_mtime),
+        file_size,
+        0, 0, 0, 0,
+        len(encoded_name),
+        0,
+    )
+    header = b"070701" + b"".join(
+        f"{value & 0xFFFFFFFF:08x}".encode("ascii") for value in fields
+    )
+    out.write(header)
+    out.write(encoded_name)
+    out.write(_newc_padding(len(header) + len(encoded_name)))
+
+    if inline_data is not None:
+        out.write(inline_data)
+    elif file_size:
+        with path.open("rb") as source:
+            shutil.copyfileobj(source, out)
+    out.write(_newc_padding(file_size))
+
+
+def _write_newc_trailer(out, inode: int) -> None:
+    """Terminate a ``newc`` archive with its required trailer record."""
+    name = b"TRAILER!!!\0"
+    fields = (inode, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, len(name), 0)
+    header = b"070701" + b"".join(
+        f"{value:08x}".encode("ascii") for value in fields
+    )
+    out.write(header)
+    out.write(name)
+    out.write(_newc_padding(len(header) + len(name)))
+
+
+def _create_initramfs(rootfs: Path, build_dir: Path) -> Path:
+    """Create a gzip-compressed ``newc`` initramfs from *rootfs*.
+
+    The serializer is intentionally self-contained: relying on a
+    ``find | cpio | gzip`` subprocess pipeline made integration builds depend
+    on three Unix executables and made the function unusable on Windows.
+    """
+    if not rootfs.is_dir():
+        raise ValueError(f"Rootfs directory does not exist: {rootfs}")
+
     initramfs = build_dir / "initramfs.cpio.gz"
+    entries = [rootfs, *sorted(rootfs.rglob("*"), key=lambda p: p.as_posix())]
+    hardlink_inodes = {}
+    hardlink_data_written = set()
+    next_inode = 1
 
-    find_proc = subprocess.Popen(
-        ["find", "."], cwd=str(rootfs), stdout=subprocess.PIPE
-    )
-    cpio_proc = subprocess.Popen(
-        ["cpio", "-o", "-H", "newc"],
-        cwd=str(rootfs),
-        stdin=find_proc.stdout,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-    )
-    # Let find_proc receive SIGPIPE if cpio_proc exits early.
-    if find_proc.stdout is not None:
-        find_proc.stdout.close()
+    with gzip.GzipFile(filename=str(initramfs), mode="wb", mtime=0) as out:
+        for path in entries:
+            metadata = path.lstat()
+            hardlink_key = None
+            if stat.S_ISREG(metadata.st_mode) and metadata.st_nlink > 1:
+                hardlink_key = (metadata.st_dev, metadata.st_ino)
 
-    with open(initramfs, "wb") as out_f:
-        gzip_proc = subprocess.Popen(["gzip"], stdin=cpio_proc.stdout, stdout=out_f)
-        if cpio_proc.stdout is not None:
-            cpio_proc.stdout.close()
-        gzip_proc.communicate()
+            inode = hardlink_inodes.get(hardlink_key)
+            if inode is None:
+                inode = next_inode
+                next_inode += 1
+                if hardlink_key is not None:
+                    hardlink_inodes[hardlink_key] = inode
 
-    cpio_proc.wait()
-    find_proc.wait()
+            include_data = (
+                hardlink_key is None or hardlink_key not in hardlink_data_written
+            )
+            relative_name = path.relative_to(rootfs).as_posix()
+            name = "." if path == rootfs else f"./{relative_name}"
+            _write_newc_entry(
+                out, path, name, metadata, inode, include_data
+            )
+            if hardlink_key is not None:
+                hardlink_data_written.add(hardlink_key)
+        _write_newc_trailer(out, next_inode)
+
     return initramfs
 
 
@@ -362,16 +455,10 @@ def register_commands(cli_group: click.Group) -> None:
         log.success(f"Rootfs: {rootfs} ({sum(1 for _ in rootfs.rglob('*') if _.is_file())} files)")
 
         # Create initramfs
-        if os.name != "nt":
-            log.step("Creating initramfs...")
-            initramfs = _create_initramfs(rootfs, build_path)
-            if initramfs.exists():
-                size_kb = initramfs.stat().st_size // 1024
-                log.success(f"Initramfs: {initramfs} ({size_kb}KB)")
-            else:
-                log.warning("Initramfs creation failed (cpio not available)")
-        else:
-            log.info("Initramfs creation skipped on Windows (requires cpio)")
+        log.step("Creating initramfs...")
+        initramfs = _create_initramfs(rootfs, build_path)
+        size_kb = initramfs.stat().st_size // 1024
+        log.success(f"Initramfs: {initramfs} ({size_kb}KB)")
 
         log.success(f"Integration build complete — {built} packages built")
 
@@ -452,7 +539,7 @@ def register_commands(cli_group: click.Group) -> None:
                 log.step("Creating initramfs...")
                 initramfs = _create_initramfs(rootfs, build_path)
             else:
-                log.error("QEMU boot requires Linux (cpio + QEMU).")
+                log.error("QEMU boot requires a Linux host kernel and QEMU.")
                 raise SystemExit(1)
         else:
             initramfs = build_path / "initramfs.cpio.gz"

--- a/tests/ebuild/test_integration_initramfs_security.py
+++ b/tests/ebuild/test_integration_initramfs_security.py
@@ -1,13 +1,12 @@
-"""Regression tests for the command-injection fix in _create_initramfs().
+"""Regression tests for portable, injection-safe initramfs creation.
 
 _create_initramfs() used to build a single shell string
 (``cd {rootfs} && find . | cpio ... > {initramfs}``) and execute it with
 ``subprocess.run(cmd, shell=True, ...)``. Both ``rootfs`` and ``build_dir``
 flow in from the ``--build-dir`` CLI option (an unrestricted click.Path()),
 so a directory name containing shell metacharacters was executed as shell
-syntax rather than treated as a literal path. These tests prove the fix
-(an argv-list Popen pipeline with no shell involved) both blocks the
-injection and still produces a correct initramfs.
+syntax rather than treated as a literal path. The implementation no longer
+starts subprocesses at all: it serializes ``newc`` with the standard library.
 
 Note on the injection check: a directory name can never contain "/" (that's
 a filesystem-level restriction on any POSIX path component, not just a
@@ -22,9 +21,49 @@ shell ever getting a chance to reinterpret it.
 """
 
 import gzip
-import subprocess
+import os
+import stat
+
+import pytest
 
 from ebuild.cli.integration import _create_initramfs
+
+
+def _newc_members(data):
+    """Parse enough of ``newc`` to validate names, metadata, and contents."""
+    members = {}
+    offset = 0
+    while True:
+        header = data[offset:offset + 110]
+        assert len(header) == 110
+        assert header[:6] == b"070701"
+        fields = [int(header[i:i + 8], 16) for i in range(6, 110, 8)]
+        inode = fields[0]
+        mode = fields[1]
+        link_count = fields[4]
+        file_size = fields[6]
+        name_size = fields[11]
+
+        offset += 110
+        encoded_name = data[offset:offset + name_size]
+        assert encoded_name.endswith(b"\0")
+        name = os.fsdecode(encoded_name[:-1])
+        offset += name_size
+        offset += -offset % 4
+
+        contents = data[offset:offset + file_size]
+        assert len(contents) == file_size
+        offset += file_size
+        offset += -offset % 4
+        members[name] = {
+            "inode": inode,
+            "mode": mode,
+            "link_count": link_count,
+            "contents": contents,
+        }
+
+        if name == "TRAILER!!!":
+            return members
 
 
 def test_create_initramfs_produces_valid_gzip_with_expected_content(tmp_path):
@@ -47,13 +86,12 @@ def test_create_initramfs_produces_valid_gzip_with_expected_content(tmp_path):
         cpio_data = f.read()
     assert cpio_data.startswith(b"07070")  # newc cpio magic
 
-    # cpio -t lists member paths; our test file must be in there.
-    result = subprocess.run(
-        ["cpio", "-t"],
-        input=cpio_data,
-        capture_output=True,
-    )
-    assert b"hello.txt" in result.stdout
+    members = _newc_members(cpio_data)
+    assert "." in members
+    assert members["./hello.txt"]["contents"] == (
+        rootfs / "hello.txt"
+    ).read_bytes()
+    assert "TRAILER!!!" in members
 
 
 def test_create_initramfs_build_dir_with_shell_metacharacters_is_not_interpreted(tmp_path):
@@ -104,10 +142,76 @@ def test_create_initramfs_rootfs_with_shell_metacharacters_is_not_interpreted(tm
         cpio_data = f.read()
     assert cpio_data.startswith(b"07070")
 
-    # The pipeline must have actually cd'd into the evil rootfs (via `cwd=`,
-    # not a shell `cd`) and archived its real content.
-    result = subprocess.run(["cpio", "-t"], input=cpio_data, capture_output=True)
-    assert b"f.txt" in result.stdout
+    # The literal rootfs path must have supplied the archived content.
+    assert _newc_members(cpio_data)["./f.txt"]["contents"] == (
+        evil_rootfs / "f.txt"
+    ).read_bytes()
 
     assert not (tmp_path / "pwned_marker2").exists()
     assert not (build_dir / "pwned_marker2").exists()
+
+
+def test_create_initramfs_marks_shebang_scripts_executable(tmp_path):
+    rootfs = tmp_path / "rootfs"
+    bin_dir = rootfs / "bin"
+    bin_dir.mkdir(parents=True)
+    executable = bin_dir / "app"
+    executable.write_bytes(b"#!/bin/sh\nexit 0\n")
+    executable.chmod(0o755)
+
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    initramfs = _create_initramfs(rootfs, build_dir)
+
+    with gzip.open(initramfs, "rb") as archive:
+        members = _newc_members(archive.read())
+
+    assert stat.S_ISDIR(members["./bin"]["mode"])
+    assert stat.S_ISREG(members["./bin/app"]["mode"])
+    assert members["./bin/app"]["mode"] & 0o111 == 0o111
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="Windows cannot reliably create symlinks"
+)
+def test_create_initramfs_preserves_symlink_target(tmp_path):
+    rootfs = tmp_path / "rootfs"
+    bin_dir = rootfs / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "app-link").symlink_to("app")
+
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    initramfs = _create_initramfs(rootfs, build_dir)
+
+    with gzip.open(initramfs, "rb") as archive:
+        members = _newc_members(archive.read())
+
+    assert stat.S_ISLNK(members["./bin/app-link"]["mode"])
+    assert members["./bin/app-link"]["contents"] == b"app"
+
+
+def test_create_initramfs_preserves_hard_links_without_duplicate_data(tmp_path):
+    rootfs = tmp_path / "rootfs"
+    rootfs.mkdir()
+    first = rootfs / "first"
+    second = rootfs / "second"
+    payload = b"shared contents" * 64
+    first.write_bytes(payload)
+    os.link(first, second)
+
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    initramfs = _create_initramfs(rootfs, build_dir)
+
+    with gzip.open(initramfs, "rb") as archive:
+        members = _newc_members(archive.read())
+
+    first_record = members["./first"]
+    second_record = members["./second"]
+    assert first_record["inode"] == second_record["inode"]
+    assert first_record["link_count"] == second_record["link_count"] == 2
+    assert {first_record["contents"], second_record["contents"]} == {
+        b"",
+        payload,
+    }


### PR DESCRIPTION
## Summary

Integration builds currently create `initramfs.cpio.gz` by launching host
`find`, `cpio`, and `gzip` processes. That toolchain is absent on Windows and
makes a core build artifact depend on Unix host utilities.

This change replaces the subprocess pipeline with a standard-library `newc`
serializer, so integration builds create the initramfs on every supported host.

## Type of Change

- [x] fix — Bug fix
- [x] test — Add or fix tests

## Changes

- Serialize gzip-compressed `newc` records directly, including required
  alignment and the `TRAILER!!!` marker.
- Preserve regular files, directories, symbolic links, metadata, and hard-link
  identity without duplicating hard-linked payloads.
- Infer executable bits for shebang scripts and ELF binaries on Windows, where
  host mode bits do not represent Linux executability.
- Run initramfs creation on Windows and remove the `cpio` requirement from the
  QEMU error message.
- Replace system-`cpio` test assertions with an internal format parser and add
  coverage for literal metacharacter paths, mode bits, symlinks, and hard links.

The record layout and hard-link behavior follow the Linux kernel's
[documented initramfs buffer format](https://www.kernel.org/doc/html/next/driver-api/early-userspace/buffer-format.html).

## Testing

- [x] Focused unit tests: `5 passed, 1 skipped`
- [x] New tests added for new functionality
- [x] Independent `bsdtar` extraction validated both hard-link names, shared
  inode identity, and payload content
- [x] `flake8 --select=F` passes for both changed Python files

Full Python suite: `288 passed, 2 skipped, 1 failed`. The single failure is an
existing Windows-only Ninja path-parsing assertion in
`test_test_target_links_like_an_executable`; it is unrelated to initramfs code
and is recorded as T-002 in `TASKS.md`.

## Pre-Submission Checklist

- [ ] All existing tests pass (one unrelated Windows failure described above)
- [x] New tests added for new functionality
- [x] Documentation updated if API changed (not applicable)
- [x] Commit messages follow `<type>(<scope>): <description>` convention
- [x] Branch is based on latest `master`

## Related Issues

None.

## Screenshots / Logs

Not applicable.

## Additional Notes

- A QEMU boot was not run on this Windows host.
- Device nodes and other special files remain unsupported and produce an
  explicit error; the generated project rootfs currently contains regular
  files, directories, and symlinks.
- The symlink test is skipped on Windows because symlink creation privileges
  are not reliably available; it runs on POSIX CI hosts.
