### PR TITLE
Make shared library test platform-aware

### DIFF
--- a/tests/ebuild/test_ninja_backend.py
+++ b/tests/ebuild/test_ninja_backend.py
@@ -45,7 +45,8 @@ def test_shared_library_uses_shared_link_rule(tmp_path):
     NinjaBackend(config, tmp_path / "build", toolchain).generate()
 
     ninja_file = (tmp_path / "build" / "build.ninja").read_text(encoding="utf-8")
-    assert "rule link_shared\n  command = $cc -shared" in ninja_file
+    shared_flag = "-dynamiclib" if sys.platform == "darwin" else "-shared"
+    assert f"rule link_shared\n  command = $cc {shared_flag}" in ninja_file
     assert "build " in ninja_file
     assert ": link_shared " in ninja_file
 


### PR DESCRIPTION
## Summary

Make the shared-library Ninja backend test platform-aware.

* Use `-dynamiclib` on macOS.
* Use `-shared` on other platforms.
* Keep the existing test assertions unchanged otherwise.

## Testing

* `python -m pytest`
* **291 passed**