### PR TITLE
fix(cli): register the integration commands on the installed entry point

### DIFF
--- a/ebuild/__main__.py
+++ b/ebuild/__main__.py
@@ -2,10 +2,10 @@
 # Copyright (c) 2026 EoS Project
 
 """Allow running ebuild as a module: python -m ebuild."""
+# The integration commands are registered on the group inside
+# ebuild.cli.commands, so `python -m ebuild` and the installed `ebuild`
+# console script expose the same command set. Importing `cli` is enough.
 from ebuild.cli.commands import cli
-from ebuild.cli.integration import register_commands
-
-register_commands(cli)
 
 if __name__ == "__main__":
     cli()

--- a/ebuild/cli/commands.py
+++ b/ebuild/cli/commands.py
@@ -28,6 +28,7 @@ import yaml
 from ebuild import __version__
 from ebuild.build.ninja_backend import NinjaBackend, PackagePaths
 from ebuild.build.toolchain import resolve_toolchain
+from ebuild.cli.integration import register_commands as _register_integration_commands
 from ebuild.cli.logger import Logger
 from ebuild.core.config import ConfigError, load_config, ProjectConfig
 from ebuild.core.graph import CycleError, DependencyGraph, build_dependency_graph
@@ -2408,3 +2409,18 @@ def _serial_ports() -> List[str]:
     for pattern in ("/dev/ttyUSB*", "/dev/ttyACM*", "/dev/tty.usb*"):
         found.extend(sorted(glob.glob(pattern)))
     return found
+
+
+# ═════════════════════════════════════════════════════════════
+#  Integration commands
+# ═════════════════════════════════════════════════════════════
+# `integration`, `qemu`, `sdk`, `package` and `models` live in
+# ebuild/cli/integration.py and are attached to the group by
+# register_commands(). That call used to live only in ebuild/__main__.py,
+# which runs for `python -m ebuild` and not for the `ebuild` console script
+# that pyproject.toml's [project.scripts] installs on PATH. The five
+# commands were therefore missing from the entry point that every user and
+# every doc actually invokes. Registering here attaches them to the group
+# itself, so both entry points -- and anything that imports `cli` -- see
+# the same CLI.
+_register_integration_commands(cli)

--- a/tests/unit/test_integration_commands_registered.py
+++ b/tests/unit/test_integration_commands_registered.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 EoS Project
+
+"""The documented integration commands must exist on the installed CLI.
+
+`integration`, `qemu`, `sdk`, `package` and `models` are defined in
+ebuild/cli/integration.py and attached to the group by register_commands().
+That call used to live only in ebuild/__main__.py, so the five commands
+existed under `python -m ebuild` and were absent from the `ebuild` console
+script that pyproject.toml installs on PATH -- the invocation the README,
+docs/architecture.md, docs/qms/quality_management_system.md and
+examples/eradar360/eos.yaml all use.
+
+These tests assert against the `cli` object named by [project.scripts], which
+is the thing the entry point actually runs, so the gap cannot come back.
+"""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from ebuild.cli.commands import cli
+
+
+# Defined in ebuild/cli/integration.py and referenced by the docs.
+INTEGRATION_COMMANDS = ["integration", "qemu", "sdk", "package", "models"]
+
+
+@pytest.mark.ebuild
+class TestIntegrationCommandsRegistered:
+    """Every integration command must be on the console-script group."""
+
+    @pytest.mark.parametrize("name", INTEGRATION_COMMANDS)
+    def test_command_is_registered(self, name):
+        assert name in cli.commands, (
+            f"'ebuild {name}' is defined in ebuild/cli/integration.py and "
+            f"documented, but is not registered on the group that "
+            f"[project.scripts] points at"
+        )
+
+    @pytest.mark.parametrize("name", INTEGRATION_COMMANDS)
+    def test_command_help_runs(self, name):
+        result = CliRunner().invoke(cli, [name, "--help"])
+        assert result.exit_code == 0, result.output
+
+    def test_entry_point_and_module_expose_the_same_commands(self):
+        """`ebuild <cmd>` and `python -m ebuild <cmd>` must not diverge.
+
+        __main__.py imports the same group object, so this asserts that
+        importing it adds nothing the console script does not already have.
+        """
+        console_script_commands = set(cli.commands)
+
+        import ebuild.__main__ as module_entry_point
+
+        assert set(module_entry_point.cli.commands) == console_script_commands
+
+    def test_documented_commands_are_reachable(self):
+        """`ebuild --help` must list the commands the docs tell users to run."""
+        result = CliRunner().invoke(cli, ["--help"])
+        assert result.exit_code == 0, result.output
+        for name in INTEGRATION_COMMANDS:
+            assert name in result.output, (
+                f"'{name}' is missing from `ebuild --help`"
+            )
+
+
+@pytest.mark.ebuild
+def test_entry_point_target_is_the_registered_group():
+    """[project.scripts] must keep pointing at the group under test.
+
+    If the entry point is ever re-pointed somewhere else, these tests would
+    keep passing while the installed `ebuild` command lost the commands
+    again. Pin the target so that change is caught here.
+    """
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    content = pyproject.read_text(encoding="utf-8")
+    assert 'ebuild = "ebuild.cli.commands:cli"' in content, (
+        "the console script no longer points at ebuild.cli.commands:cli, so "
+        "these tests no longer cover the installed command"
+    )


### PR DESCRIPTION
## Summary

The installed `ebuild` console script did not expose five documented commands: `integration`, `qemu`, `sdk`, `package`, and `models`.

`pyproject.toml` maps the console script directly to `ebuild.cli.commands:cli`, while these five commands are defined in `ebuild/cli/integration.py` and attached through `register_commands()`.

Previously, `register_commands()` was only called from `ebuild/__main__.py`, which runs for `python -m ebuild` but not for the installed `ebuild` console script.

As a result:

- `python -m ebuild --help` exposed all 25 commands.
- `ebuild --help` exposed only 20 commands.
- Documented commands such as `ebuild sdk` failed with `No such command`.

This change registers the integration commands directly on the CLI group so both entry points expose the same command set.

## Type of Change

<!-- Check all that apply -->

- [ ] feat — New feature
- [x] fix — Bug fix
- [ ] docs — Documentation only
- [ ] style — Formatting, no code change
- [ ] refactor — Code restructuring without behavior change
- [x] test — Add or fix tests
- [ ] build — Build system or dependency changes
- [ ] ci — CI/CD pipeline changes
- [ ] perf — Performance improvement

## Changes

<!-- List each change made in this PR -->

- Updated `ebuild/cli/commands.py` to call `register_commands(cli)` after the CLI group and its commands are defined.
- Removed the now-redundant registration from `ebuild/__main__.py`.
- Added `tests/unit/test_integration_commands_registered.py` with regression coverage for all five commands and both CLI entry points.

## Testing

<!-- How was this tested? Which test suites were run? -->

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing performed
- [x] New tests added for new functionality

Test environment:

- WSL Ubuntu
- Python 3.10
- pytest 9.1.1

Full test suite:

```text
$ python -m pytest -q

304 passed in 3.24s
```

Manual validation:

```text
$ ebuild --help
```

Confirmed that the installed console script now exposes:

```text
integration
models
package
qemu
sdk
```

The new regression suite also verifies that:

- all five integration commands are registered on the installed CLI group;
- `--help` succeeds for each command;
- `ebuild` and `python -m ebuild` expose the same command set;
- `[project.scripts]` continues to point to the CLI object being tested.

## Pre-Submission Checklist

- [ ] Code compiles without warnings (`-Wall -Wextra -Werror` for C)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Documentation updated if API changed — no API change; this change makes the existing documentation accurate
- [x] Commit messages follow `<type>(<scope>): <description>` convention
- [x] Branch is rebased on latest master

## Related Issues

No issue is closed by this PR.

Related: #77 introduces a different `package` command. `integration.py` already defines a `package` command for producing a hardware-target deliverable ZIP, so if both implementations remain, the project may need to decide which behavior should own the `ebuild package` command name.

This PR does not attempt to resolve that separate design question.

## Screenshots / Logs

Before this change:

```text
$ ebuild sdk --target stm32f4 --output out
Usage: ebuild [OPTIONS] COMMAND [ARGS]...
Error: No such command 'sdk'.

$ python3 -m ebuild sdk --target stm32f4 --output out
EoS SDK generated for stm32f4
```

The installed console script exposed 20 commands while `python -m ebuild` exposed 25.

After this change:

```text
$ python -m pytest -q
304 passed in 3.24s
```

`ebuild --help` now exposes the same five previously missing commands: `integration`, `models`, `package`, `qemu`, and `sdk`.

## Additional Notes

Registering the commands on the CLI group itself, rather than changing the `[project.scripts]` entry point, keeps the installed `ebuild` command, `python -m ebuild`, and code that imports `cli` using the same command set.

There is no import cycle introduced by this change: `integration.py` imports `ebuild.cli.logger`, `ebuild.system.rootfs`, and `ebuild`, none of which import `ebuild.cli.commands`.

A separate related issue exists in the plugin system: `discover_plugins()`, `register_plugin_commands()`, and the plugin notification hooks are currently not wired into CLI startup despite being documented. That is intentionally outside the scope of this PR.