### PR TITLE
ci: pin EoSim to a tag that exists

### DIFF
--- a/.github/workflows/eosim-sanity.yml
+++ b/.github/workflows/eosim-sanity.yml
@@ -6,7 +6,11 @@ on:
   workflow_dispatch:
 
 env:
-  EOSIM_VERSION: "0.1.0"
+  # v0.1.0 has never existed. embeddedos-org/EoSim tags v1.0.0 through
+  # v3.0.1, so `git clone --branch v0.1.0` fails with "Remote branch
+  # v0.1.0 not found in upstream origin" and this workflow has never had a
+  # green run. v1.5.0 is the release marked Latest and installs from source.
+  EOSIM_VERSION: "1.5.0"
 
 permissions:
   contents: read


### PR DESCRIPTION
`EoSim Sanity` has never had a green run in this repository. It is a nightly workflow, so it does not gate pull requests — it is simply red every morning.

## The cause

`EOSIM_VERSION` is `"0.1.0"`, and **`embeddedos-org/EoSim` has no such tag**. Its tags run `v1.0.0` through `v3.0.1`:

```
$ git clone --depth 1 --branch v0.1.0 .../EoSim.git /tmp/EoSim
fatal: Remote branch v0.1.0 not found in upstream origin

$ pip install -e /tmp/EoSim
ERROR: file:///tmp/EoSim does not appear to be a Python project:
neither 'setup.py' nor 'pyproject.toml' found
```

The second message is a red herring that makes this look like an EoSim packaging problem. The directory is empty *because the clone failed* — EoSim is a perfectly normal Python project, and `v1.5.0` carries a `pyproject.toml` declaring `name = "eosim"` with a console entry point.

Pinned to **v1.5.0**, the release marked Latest.

## Verified, not assumed

I ran exactly what the workflow runs:

```
git clone --depth 1 --branch v1.5.0 .../EoSim.git /tmp/EoSim
pip install /tmp/EoSim        -> rc=0
eosim --version               -> eosim, version 2.0.0
eosim list                    -> rc=0
eosim doctor                  -> rc=0
```

Those four are every EoSim command this workflow invokes.

## One caveat worth recording

`eosim list` prints `Available platforms (0)` while `discover_platforms()` on the same directory returns 149 — a display bug inside EoSim, not something this workflow can fix. It exits 0, so the sanity steps pass either way. Flagging it rather than leaving it to surprise the next person.
