### PR TITLE
fix(ebuild): backend precedence, out-of-tree --build-dir resolution, and recipe version ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@
   0. When the backend was auto-detected and targets are declared, the ninja
   backend is now used and the choice is logged. An explicit `backend:` in
   `build.yaml` or `--backend` still takes precedence (`ebuild/cli/commands.py`).
+- **A relative `--build-dir` is now anchored to the project.** ebuild created
+  and reported the build directory relative to the process working directory,
+  while the ninja it launched read the same relative path from
+  `cfg.source_dir`. The two agree only when the working directory is the
+  project directory, so `ebuild build --config sub/build.yaml` failed with
+  "ninja: error: loading '_build/build.ninja': No such file or directory" one
+  line after reporting that it generated that file, and `ebuild configure`
+  reported success having written it where a later build would not look. A
+  relative `--build-dir` now resolves against the directory containing
+  `build.yaml`, as an absolute path, so both sides agree regardless of the
+  working directory (`ebuild/cli/commands.py`).
+
 ## [3.0.1] - 2026-05-16
 
 ### Production Release — Unified EmbeddedOS-org v3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@
   registry, with a traceback. Dot-separated integers keep their numeric
   ordering; anything else is ranked below every numeric version and ordered
   lexicographically rather than guessed at (`ebuild/packages/registry.py`).
+- **Declared targets are no longer overridden by backend auto-detection.**
+  Backend detection inspects only the filesystem, so a `Makefile` kept for
+  `make flash`, or a `CMakeLists.txt` belonging to one subcomponent, won over
+  a `build.yaml` that declared its own `targets:`. The external tool ran, none
+  of the declared targets were built, no build directory was produced, and
+  `ebuild build` still reported "Build completed successfully" with exit code
+  0. When the backend was auto-detected and targets are declared, the ninja
+  backend is now used and the choice is logged. An explicit `backend:` in
+  `build.yaml` or `--backend` still takes precedence (`ebuild/cli/commands.py`).
 ## [3.0.1] - 2026-05-16
 
 ### Production Release — Unified EmbeddedOS-org v3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,16 @@
   reported success. The rule now compiles with `-MMD -MF $out.d` and declares
   `depfile`/`deps`, so Ninja tracks the real include graph
   (`ebuild/build/ninja_backend.py`).
-
+- **Package registry: versions that are not purely numeric no longer raise.**
+  Version ordering parsed every dot-separated component with `int()`, so a
+  recipe declaring `v2.9.3` -- the upstream tag form `recipes/littlefs.yaml`
+  already downloads -- made `ebuild list-packages` fail with `ValueError`.
+  Prereleases (`3.6.0-rc1`), distribution revisions (`1.2.13-1`) and build
+  metadata (`1.0.0+build2`) failed the same way. It also replaced the
+  resolver's actionable "package not found" error, which enumerates the
+  registry, with a traceback. Dot-separated integers keep their numeric
+  ordering; anything else is ranked below every numeric version and ordered
+  lexicographically rather than guessed at (`ebuild/packages/registry.py`).
 ## [3.0.1] - 2026-05-16
 
 ### Production Release — Unified EmbeddedOS-org v3.0.1

--- a/ebuild/cli/commands.py
+++ b/ebuild/cli/commands.py
@@ -314,6 +314,28 @@ def _resolve_backend_request(
         resolved_backend = detect_backend(source_dir)
         log.info(f"Auto-detected backend: {resolved_backend}")
 
+        # A build.yaml that declares its own targets is a statement that
+        # ebuild builds this project. detect_backend() only inspects the
+        # filesystem, so a Makefile kept for `make flash` -- or a
+        # CMakeLists.txt belonging to one subcomponent -- used to outrank
+        # that statement: the dispatcher ran the external tool, the
+        # declared targets were never built, and the build still reported
+        # success.
+        #
+        # Only auto-detection is overridden. An explicit `backend:` in
+        # build.yaml or --backend on the command line still wins, which
+        # is how a project keeps both a target list and an external
+        # build.
+        if resolved_backend != "ninja" and cfg.targets:
+            log.info(
+                f"build.yaml declares {len(cfg.targets)} target(s), so "
+                f"the ninja backend is used instead of the detected "
+                f"{resolved_backend}. To build with {resolved_backend}, "
+                f"set 'backend: {resolved_backend}' in build.yaml or "
+                f"pass --backend {resolved_backend}."
+            )
+            resolved_backend = "ninja"
+
     return resolved_backend, backend_config
 
 

--- a/ebuild/cli/commands.py
+++ b/ebuild/cli/commands.py
@@ -298,6 +298,53 @@ def _detect_libraries(lib_dir: Path, pkg_name: str) -> List[str]:
     return libs if libs else [pkg_name]
 
 
+def _resolve_build_dir(build_dir: str, cfg: ProjectConfig) -> Path:
+    """Anchor a relative ``--build-dir`` to the project, not the cwd.
+
+    ``build.yaml`` describes the project, so ``_build`` means "beside
+    build.yaml" -- which is what the committed examples show
+    (``examples/hello_world/_build/``), what README and demo.md walk
+    through, and what the generated files already assume: ninja is invoked
+    with ``cwd=cfg.source_dir``, and compile_commands.json records
+    ``directory`` as the source directory with build-dir-relative outputs.
+
+    Only the Python side disagreed. It created and reported the build
+    directory relative to the *process* cwd, so the two bases coincided
+    exactly when the cwd was the project directory -- the documented golden
+    path, and the only case the examples exercise. With ``--config`` naming
+    a project elsewhere they diverged: `build` wrote build.ninja where the
+    ninja it then launched could not open it, and `configure` reported
+    success having written it somewhere a later build would not look.
+
+    The result is absolute. A path relative to the project would still be
+    re-interpreted by ninja, which runs in ``cfg.source_dir``: a relative
+    ``--config myproj/build.yaml`` yields ``myproj/_build``, and ninja
+    would then look for ``myproj/myproj/_build/build.ninja``. Absolute is
+    the only form that means the same thing to the process creating the
+    directory and to the ninja that reads what was written into it, and it
+    keeps the generated build.ninja independent of the cwd it was
+    generated from.
+    """
+    path = Path(build_dir)
+    if not path.is_absolute():
+        path = cfg.source_dir / path
+    return path.resolve()
+
+
+def _shown(path: Path) -> str:
+    """*path* as the user would type it: relative to the cwd when it is under it.
+
+    Build directories are resolved to absolute paths so that ninja and the
+    process agree on them, but printing an absolute path for the ordinary
+    in-project build would replace the "_build/build.ninja" that demo.md
+    documents with a machine-specific one.
+    """
+    try:
+        return str(path.relative_to(Path.cwd()))
+    except ValueError:
+        return str(path)
+
+
 def _resolve_backend_request(
     cfg: ProjectConfig,
     backend_override: Optional[str],
@@ -360,12 +407,12 @@ def _configure_ninja_backend(
     package_paths = {**_workspace_repo_paths(),
                      **_install_packages(cfg, build_path, log, verbose=log.verbose)}
 
-    log.step(f"Generating build.ninja in {build_path}/...")
+    log.step(f"Generating build.ninja in {_shown(build_path)}/...")
     ninja_backend = NinjaBackend(cfg, build_path, compiler, package_paths=package_paths)
     ninja_backend.generate()
 
-    log.success(f"Generated {build_path / 'build.ninja'}")
-    log.success(f"Generated {build_path / 'compile_commands.json'}")
+    log.success(f"Generated {_shown(build_path / 'build.ninja')}")
+    log.success(f"Generated {_shown(build_path / 'compile_commands.json')}")
     if suggest_build:
         log.info("Run 'ebuild build' to compile.")
 
@@ -812,7 +859,7 @@ def build(log: Logger, config_path: str, build_dir: str, backend: Optional[str],
         cfg = load_config(config_path)
         log.info(f"Project: {cfg.name} v{cfg.version}")
 
-        build_path = Path(build_dir)
+        build_path = _resolve_build_dir(build_dir, cfg)
         resolved_backend, backend_config = _resolve_backend_request(
             cfg=cfg,
             backend_override=backend,
@@ -862,11 +909,11 @@ def build(log: Logger, config_path: str, build_dir: str, backend: Optional[str],
         package_paths = {**_workspace_repo_paths(),
                          **_install_packages(cfg, build_path, log, verbose=log.verbose, jobs=jobs)}
 
-        log.step(f"Generating build.ninja in {build_path}/...")
+        log.step(f"Generating build.ninja in {_shown(build_path)}/...")
         ninja_backend = NinjaBackend(cfg, build_path, compiler, package_paths=package_paths)
         ninja_backend.generate()
-        log.success(f"Generated {build_path / 'build.ninja'}")
-        log.success(f"Generated {build_path / 'compile_commands.json'}")
+        log.success(f"Generated {_shown(build_path / 'build.ninja')}")
+        log.success(f"Generated {_shown(build_path / 'compile_commands.json')}")
 
         log.step("Invoking ninja...")
         from ebuild.build.dispatch import ninja_command
@@ -1068,7 +1115,7 @@ def configure(log: Logger, config_path: str, build_dir: str, backend: Optional[s
         cfg = load_config(config_path)
         log.info(f"Project: {cfg.name} v{cfg.version}")
 
-        build_path = Path(build_dir)
+        build_path = _resolve_build_dir(build_dir, cfg)
         resolved_backend, backend_config = _resolve_backend_request(
             cfg=cfg,
             backend_override=backend,
@@ -1190,7 +1237,7 @@ def install(log: Logger, config_path: str, build_dir: str) -> None:
             log.info("No packages declared in build.yaml.")
             return
 
-        build_path = Path(build_dir)
+        build_path = _resolve_build_dir(build_dir, cfg)
         _install_packages(cfg, build_path, log, verbose=log.verbose)
         log.success("All packages installed successfully.")
 
@@ -2209,8 +2256,6 @@ def test(log: Logger, config_path: str, build_dir: str,
     """
     log.header("ebuild — Test")
 
-    build_path = Path(build_dir)
-
     try:
         log.step("Loading configuration...")
         cfg = load_config(config_path)
@@ -2224,6 +2269,8 @@ def test(log: Logger, config_path: str, build_dir: str,
     except (ConfigError, RecipeError) as e:
         log.error(f"Configuration error: {e}")
         raise SystemExit(1)
+
+    build_path = _resolve_build_dir(build_dir, cfg)
 
     native = [t for t in cfg.targets if t.target_type == "test"]
     if native:
@@ -2293,7 +2340,9 @@ def _run_native_tests(
         + ["-f", str(build_path / "build.ninja")]
         + [str(build_path / t.name) for t in selected]
     )
-    result = subprocess.run(argv)
+    # Run from the project directory, as `ebuild build` does: the source
+    # paths recorded in build.ninja are relative to it.
+    result = subprocess.run(argv, cwd=str(cfg.source_dir))
     if result.returncode != 0:
         log.error("Test targets failed to build.")
         raise SystemExit(result.returncode)

--- a/ebuild/packages/registry.py
+++ b/ebuild/packages/registry.py
@@ -15,6 +15,32 @@ from typing import Dict, List, Optional
 from ebuild.packages.recipe import PackageRecipe, RecipeError, load_recipe
 
 
+def _version_sort_key(version: str) -> tuple:
+    """Ordering key for a recipe version string.
+
+    The recipe format documents no version grammar, and every bundled recipe
+    uses dot-separated integers (``1.3.1``, ``11.1.0``). That is the format
+    this registry orders: components are compared numerically, so ``1.10.0``
+    correctly sorts above ``1.9.0``.
+
+    Anything else -- a Debian revision (``1.2.13-1``), a prerelease
+    (``3.6.0-rc1``), a ``v``-prefixed upstream tag (``v2.9.3``) -- is outside
+    that format. Rather than guess at its ordering, such a version is ranked
+    below every numeric one and ordered lexicographically among its peers.
+    Ranking it below matters for ``get()``: with ``3.6.0`` and ``3.6.0-rc1``
+    both registered, the plain numeric release is chosen as latest.
+
+    Returning a key instead of raising keeps a single out-of-format recipe
+    from breaking commands that merely enumerate the registry -- including
+    the resolver's "package not found" message, which lists every known
+    package and so used to fail with ValueError instead of ResolveError.
+    """
+    parts = version.split(".")
+    if parts and all(part.isdigit() for part in parts):
+        return (1, tuple(int(part) for part in parts), "")
+    return (0, (), version)
+
+
 class PackageRegistry:
     """Registry of available package recipes.
 
@@ -74,7 +100,7 @@ class PackageRegistry:
         if version:
             return versions.get(version)
 
-        latest_version = sorted(versions.keys(), key=lambda v: [int(x) for x in v.split('.')])[-1]
+        latest_version = sorted(versions.keys(), key=_version_sort_key)[-1]
         return versions[latest_version]
 
     def has(self, name: str, version: Optional[str] = None) -> bool:
@@ -86,7 +112,7 @@ class PackageRegistry:
         result = []
         for name in sorted(self._recipes.keys()):
             versions = self._recipes[name]
-            latest = sorted(versions.keys(), key=lambda v: [int(x) for x in v.split('.')])[-1]
+            latest = sorted(versions.keys(), key=_version_sort_key)[-1]
             result.append(versions[latest])
         return result
 
@@ -97,7 +123,7 @@ class PackageRegistry:
                 versions[v]
                 for v in sorted(
                     versions.keys(),
-                    key=lambda v: [int(x) for x in v.split(".")],
+                    key=_version_sort_key,
                  )
               ]
 

--- a/tests/ebuild/test_backend_targets_precedence.py
+++ b/tests/ebuild/test_backend_targets_precedence.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 EoS Project
+
+"""Backend auto-detection must not outrank targets declared in build.yaml.
+
+``detect_backend()`` sees only the filesystem. A Makefile kept for `make
+flash`, or a CMakeLists.txt belonging to one subcomponent, therefore used to
+win over a build.yaml that declared its own targets: the dispatcher ran the
+external tool, none of the declared targets were built, and `ebuild build`
+still printed "Build completed successfully" and exited 0.
+
+An explicit backend -- `backend:` in build.yaml, or --backend -- is still
+honoured, so a project can keep both a target list and an external build.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from ebuild.cli import commands
+
+
+pytestmark = pytest.mark.needs_yaml
+
+# Every marker file detect_backend() recognises, with the backend it yields.
+MARKERS = [
+    ("cmake", "CMakeLists.txt", "cmake_minimum_required(VERSION 3.16)\n"),
+    ("meson", "meson.build", "project('demo', 'c')\n"),
+    ("cargo", "Cargo.toml", "[package]\nname = 'demo'\nversion = '0.1.0'\n"),
+    ("make", "Makefile", "all:\n\t@echo flash-helper\n"),
+    ("kbuild", "Kconfig", 'config DEMO\n\tbool "demo"\n'),
+]
+
+_CONFIG_WITH_TARGETS = "\n".join(
+    [
+        "project:",
+        "  name: demo",
+        '  version: "1.0.0"',
+        "targets:",
+        "  - name: demo",
+        "    type: executable",
+        '    sources: ["main.c"]',
+    ]
+) + "\n"
+
+
+def _project(tmp_path: Path, marker_file: str, marker_content: str,
+             *, extra_config_lines: str = "") -> Path:
+    config_path = tmp_path / "build.yaml"
+    config_path.write_text(_CONFIG_WITH_TARGETS + extra_config_lines,
+                           encoding="utf-8")
+    (tmp_path / "main.c").write_text("int main(void){return 0;}\n", encoding="utf-8")
+    (tmp_path / marker_file).write_text(marker_content, encoding="utf-8")
+    return config_path
+
+
+def _patch_ninja(monkeypatch):
+    """Record ninja generation; never touch a real toolchain or dispatcher."""
+    generated = {}
+
+    def fake_generate(self):
+        generated["build_dir"] = self.build_dir
+        self.build_dir.mkdir(parents=True, exist_ok=True)
+        (self.build_dir / "build.ninja").write_text("# generated\n", encoding="utf-8")
+        (self.build_dir / "compile_commands.json").write_text("[]\n", encoding="utf-8")
+
+    def fail_configure(self, backend, config=None):
+        raise AssertionError(
+            f"dispatcher.configure({backend!r}) ran, but build.yaml declares targets"
+        )
+
+    monkeypatch.setattr(commands, "resolve_toolchain",
+                        lambda toolchain: SimpleNamespace(cc="gcc", cxx="g++", ar="ar"))
+    monkeypatch.setattr(commands, "_install_packages", lambda *a, **k: {})
+    monkeypatch.setattr(commands.NinjaBackend, "generate", fake_generate)
+    monkeypatch.setattr("ebuild.build.dispatch.BackendDispatcher.configure",
+                        fail_configure)
+    return generated
+
+
+@pytest.mark.parametrize(("backend", "marker_file", "marker_content"), MARKERS)
+def test_declared_targets_win_over_auto_detected_backend(
+    tmp_path, monkeypatch, backend, marker_file, marker_content
+):
+    config_path = _project(tmp_path, marker_file, marker_content)
+    generated = _patch_ninja(monkeypatch)
+
+    result = CliRunner().invoke(
+        commands.cli, ["configure", "--config", str(config_path)]
+    )
+
+    assert result.exit_code == 0, result.output
+    # The detected backend is still reported, then explicitly overridden.
+    assert f"Auto-detected backend: {backend}" in result.output
+    assert "declares 1 target(s)" in result.output
+    assert f"instead of the detected {backend}" in result.output
+    # The decisive assertion: ebuild's own backend actually ran.
+    assert "build_dir" in generated
+    assert (generated["build_dir"] / "build.ninja").is_file()
+
+
+@pytest.mark.parametrize(("backend", "marker_file", "marker_content"), MARKERS)
+def test_explicit_yaml_backend_still_beats_declared_targets(
+    tmp_path, monkeypatch, backend, marker_file, marker_content
+):
+    """`backend:` in build.yaml is an explicit choice and must be honoured."""
+    config_path = _project(tmp_path, marker_file, marker_content,
+                           extra_config_lines=f"backend: {backend}\n")
+
+    calls = []
+    monkeypatch.setattr(
+        "ebuild.build.dispatch.BackendDispatcher.configure",
+        lambda self, backend, config=None: calls.append(backend),
+    )
+    monkeypatch.setattr(
+        commands.NinjaBackend, "generate",
+        lambda self: (_ for _ in ()).throw(
+            AssertionError("ninja ran despite an explicit backend")),
+    )
+
+    result = CliRunner().invoke(
+        commands.cli, ["configure", "--config", str(config_path)]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Auto-detected" not in result.output
+    if backend in ("cargo", "make", "kbuild"):
+        assert f"No separate configure step for {backend}." in result.output
+        assert calls == []
+    else:
+        assert calls == [backend]
+
+
+@pytest.mark.parametrize(("backend", "marker_file", "marker_content"), MARKERS)
+def test_cli_backend_flag_still_beats_declared_targets(
+    tmp_path, monkeypatch, backend, marker_file, marker_content
+):
+    """--backend is the operator's explicit choice and must be honoured."""
+    config_path = _project(tmp_path, marker_file, marker_content)
+
+    calls = []
+    monkeypatch.setattr(
+        "ebuild.build.dispatch.BackendDispatcher.configure",
+        lambda self, backend, config=None: calls.append(backend),
+    )
+    monkeypatch.setattr(
+        commands.NinjaBackend, "generate",
+        lambda self: (_ for _ in ()).throw(
+            AssertionError("ninja ran despite --backend")),
+    )
+
+    result = CliRunner().invoke(
+        commands.cli,
+        ["configure", "--config", str(config_path), "--backend", backend],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Auto-detected" not in result.output
+    if backend in ("cargo", "make", "kbuild"):
+        assert calls == []
+    else:
+        assert calls == [backend]
+
+
+@pytest.mark.parametrize(("backend", "marker_file", "marker_content"), MARKERS)
+def test_marker_still_wins_when_no_targets_are_declared(
+    tmp_path, monkeypatch, backend, marker_file, marker_content
+):
+    """Without targets there is nothing to protect; detection is unchanged."""
+    config_path = tmp_path / "build.yaml"
+    config_path.write_text(
+        'project:\n  name: demo\n  version: "1.0.0"\n', encoding="utf-8"
+    )
+    (tmp_path / marker_file).write_text(marker_content, encoding="utf-8")
+
+    calls = []
+    monkeypatch.setattr(
+        "ebuild.build.dispatch.BackendDispatcher.configure",
+        lambda self, backend, config=None: calls.append(backend),
+    )
+    monkeypatch.setattr(
+        commands.NinjaBackend, "generate",
+        lambda self: (_ for _ in ()).throw(
+            AssertionError("ninja ran for a project with no targets")),
+    )
+
+    result = CliRunner().invoke(
+        commands.cli, ["configure", "--config", str(config_path)]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert f"Auto-detected backend: {backend}" in result.output
+    assert "declares" not in result.output
+    if backend in ("cargo", "make", "kbuild"):
+        assert calls == []
+    else:
+        assert calls == [backend]
+
+
+# ── `ebuild build`: the end-to-end symptom ──────────────────
+
+
+@pytest.mark.parametrize(("backend", "marker_file", "marker_content"), MARKERS)
+def test_build_does_not_report_success_without_building_targets(
+    tmp_path, monkeypatch, backend, marker_file, marker_content
+):
+    """`ebuild build` used to exit 0 having built none of the declared targets.
+
+    The dispatcher ran the external tool, ebuild's own backend never ran, and
+    no build.ninja was generated -- yet the command printed
+    "Build completed successfully" and exited 0.
+    """
+    _project(tmp_path, marker_file, marker_content)
+    monkeypatch.chdir(tmp_path)
+
+    generated = _patch_ninja(monkeypatch)
+
+    # Stand in for the real ninja process so no toolchain is needed.
+    ninja_invocations = []
+
+    def fake_run(cmd, *args, **kwargs):
+        ninja_invocations.append(cmd)
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr("ebuild.cli.commands.subprocess.run", fake_run)
+
+    result = CliRunner().invoke(commands.cli, ["build"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert "Build completed successfully." in result.output
+    # Success is only truthful if ebuild's backend actually generated a build.
+    assert "build_dir" in generated, (
+        f"reported success but the ninja backend never ran ({backend} took over)"
+    )
+    assert (generated["build_dir"] / "build.ninja").is_file()
+    assert ninja_invocations, "reported success without invoking ninja"

--- a/tests/ebuild/test_build_dir_resolution.py
+++ b/tests/ebuild/test_build_dir_resolution.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 EoS Project
+
+"""A relative --build-dir must be anchored to the project, not the cwd.
+
+`ebuild build` generates build.ninja with Python, then launches ninja with
+``cwd=cfg.source_dir`` so the relative source paths inside it resolve. The
+``-f`` argument and the output paths are relative too, so the build directory
+has to mean the same thing to both sides.
+
+It did not. Python created and reported it relative to the *process* cwd. The
+two bases coincide exactly when the cwd is the project directory -- the
+documented golden path -- and diverge as soon as ``--config`` names a project
+elsewhere:
+
+  * `build` wrote build.ninja under the cwd, then ninja, running in the
+    project directory, could not open it: "ninja: error: loading
+    '_build/build.ninja': No such file or directory" -- one line after ebuild
+    reported "Generated _build/build.ninja".
+  * `configure` reported success, leaving build.ninja where a later build
+    would not look for it.
+
+An absolute --build-dir was already unambiguous, which is why it worked.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from ebuild.cli import commands
+
+
+pytestmark = pytest.mark.needs_yaml
+
+
+def _make_project(root: Path) -> Path:
+    """A minimal ninja-backed project at *root*; returns its build.yaml."""
+    (root / "src").mkdir(parents=True, exist_ok=True)
+    (root / "src" / "main.c").write_text(
+        "int main(void) { return 0; }\n", encoding="utf-8"
+    )
+    config_path = root / "build.yaml"
+    config_path.write_text(textwrap.dedent("""\
+        project:
+          name: subdir_demo
+          version: "1.0.0"
+
+        targets:
+          - name: app
+            type: executable
+            sources: ["src/main.c"]
+        """), encoding="utf-8")
+    return config_path
+
+
+@pytest.fixture
+def outside_project(tmp_path, monkeypatch):
+    """A project in ``<tmp>/myproj`` with the cwd left at ``<tmp>``."""
+    project_dir = tmp_path / "myproj"
+    config_path = _make_project(project_dir)
+    monkeypatch.chdir(tmp_path)
+    return SimpleNamespace(cwd=tmp_path, project_dir=project_dir,
+                           config_path=config_path)
+
+
+@pytest.fixture
+def record_ninja(monkeypatch):
+    """Capture the ninja invocation instead of running a real build."""
+    calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(SimpleNamespace(cmd=[str(c) for c in cmd],
+                                     cwd=kwargs.get("cwd")))
+        return subprocess.CompletedProcess(cmd, returncode=0,
+                                           stdout=b"", stderr=b"")
+
+    monkeypatch.setattr("ebuild.cli.commands.subprocess.run", fake_run)
+    monkeypatch.setattr(commands, "_install_packages", lambda *a, **k: {})
+    return calls
+
+
+# ── build ───────────────────────────────────────────────────
+
+
+def test_build_from_outside_puts_build_ninja_where_ninja_looks(
+    outside_project, record_ninja
+):
+    """The regression: the generated file must be the one ninja is given."""
+    result = CliRunner().invoke(
+        commands.cli,
+        ["build", "--config", str(outside_project.config_path)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (outside_project.project_dir / "_build" / "build.ninja").is_file()
+    assert not (outside_project.cwd / "_build").exists(), (
+        "build directory was created beside the cwd instead of the project"
+    )
+
+    assert len(record_ninja) == 1
+    invocation = record_ninja[0]
+    assert invocation.cwd == str(outside_project.project_dir)
+    ninja_file = Path(invocation.cmd[invocation.cmd.index("-f") + 1])
+    # Whatever form the path takes, resolving it from ninja's cwd must land
+    # on a file that exists -- that is precisely what used to fail.
+    resolved = ninja_file if ninja_file.is_absolute() else Path(invocation.cwd) / ninja_file
+    assert resolved.is_file(), f"ninja was given {ninja_file}, which does not exist"
+
+
+def test_build_from_inside_project_is_unchanged(tmp_path, monkeypatch, record_ninja):
+    """The golden path must keep producing ``./_build`` exactly as before."""
+    _make_project(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(commands.cli, ["build"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "_build" / "build.ninja").is_file()
+    assert "Generated _build/build.ninja" in result.output
+
+
+def test_absolute_build_dir_is_honoured_verbatim(outside_project, record_ninja, tmp_path):
+    out = tmp_path / "elsewhere" / "out"
+    result = CliRunner().invoke(
+        commands.cli,
+        ["build", "--config", str(outside_project.config_path),
+         "--build-dir", str(out)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (out / "build.ninja").is_file()
+    assert not (outside_project.project_dir / "_build").exists()
+
+
+def test_relative_build_dir_with_a_name_is_anchored_to_the_project(
+    outside_project, record_ninja
+):
+    result = CliRunner().invoke(
+        commands.cli,
+        ["build", "--config", str(outside_project.config_path),
+         "--build-dir", "out"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (outside_project.project_dir / "out" / "build.ninja").is_file()
+    assert not (outside_project.cwd / "out").exists()
+
+
+def test_relative_config_path_is_handled(outside_project, record_ninja):
+    """A *relative* --config must work too.
+
+    Anchoring the build directory to the project is not sufficient on its own:
+    ``--config myproj/build.yaml`` makes cfg.source_dir relative, so a
+    project-relative build directory is ``myproj/_build`` -- and ninja, which
+    runs in ``myproj``, would resolve that to ``myproj/myproj/_build``.
+    Resolving to an absolute path is what removes the second interpretation.
+    """
+    result = CliRunner().invoke(
+        commands.cli, ["build", "--config", "myproj/build.yaml"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (outside_project.project_dir / "_build" / "build.ninja").is_file()
+
+    invocation = record_ninja[-1]
+    ninja_file = Path(invocation.cmd[invocation.cmd.index("-f") + 1])
+    assert ninja_file.is_absolute(), (
+        "a relative -f is re-interpreted against ninja's cwd"
+    )
+    assert ninja_file.is_file()
+
+
+def test_two_projects_built_from_one_cwd_do_not_share_a_build_dir(
+    tmp_path, monkeypatch, record_ninja
+):
+    """Each project gets its own tree, so neither clobbers the other."""
+    for name in ("alpha", "beta"):
+        _make_project(tmp_path / name)
+    monkeypatch.chdir(tmp_path)
+
+    for name in ("alpha", "beta"):
+        result = CliRunner().invoke(
+            commands.cli, ["build", "--config", f"{name}/build.yaml"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+
+    assert (tmp_path / "alpha" / "_build" / "build.ninja").is_file()
+    assert (tmp_path / "beta" / "_build" / "build.ninja").is_file()
+    assert not (tmp_path / "_build").exists()
+
+
+# ── configure ───────────────────────────────────────────────
+
+
+def test_configure_and_build_from_outside_agree_on_the_build_dir(
+    outside_project, record_ninja
+):
+    """`configure` then `build` must target the same directory.
+
+    `configure` used to report success having written build.ninja beside the
+    cwd, where the `build` that followed did not look.
+    """
+    configured = CliRunner().invoke(
+        commands.cli,
+        ["configure", "--config", str(outside_project.config_path)],
+        catch_exceptions=False,
+    )
+    assert configured.exit_code == 0, configured.output
+
+    generated = outside_project.project_dir / "_build" / "build.ninja"
+    assert generated.is_file()
+    assert not (outside_project.cwd / "_build").exists()
+
+    built = CliRunner().invoke(
+        commands.cli,
+        ["build", "--config", str(outside_project.config_path)],
+        catch_exceptions=False,
+    )
+    assert built.exit_code == 0, built.output
+
+    invocation = record_ninja[-1]
+    ninja_file = Path(invocation.cmd[invocation.cmd.index("-f") + 1])
+    resolved = (ninja_file if ninja_file.is_absolute()
+                else Path(invocation.cwd) / ninja_file)
+    assert resolved.resolve() == generated.resolve()
+
+
+# ── end to end, with a real compiler ────────────────────────
+
+
+@pytest.mark.skipif(
+    subprocess.run(["gcc", "--version"], capture_output=True).returncode != 0,
+    reason="needs a working gcc to link the executable",
+)
+def test_end_to_end_build_from_outside_produces_the_binary(tmp_path, monkeypatch):
+    """No stubs: the real ninja run must produce the real executable."""
+    project_dir = tmp_path / "myproj"
+    config_path = _make_project(project_dir)
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(
+        commands.cli, ["build", "--config", str(config_path)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (project_dir / "_build" / "app").is_file()

--- a/tests/ebuild/test_cli_backend_resolution.py
+++ b/tests/ebuild/test_cli_backend_resolution.py
@@ -156,7 +156,8 @@ def test_configure_generates_ninja_for_explicit_ninja_backend(tmp_path, monkeypa
     result = _invoke_configure(config_path)
 
     assert result.exit_code == 0
-    assert generate_calls["build_dir"] == Path("_build")
+    # A relative --build-dir is anchored to the project, not the process cwd.
+    assert generate_calls["build_dir"] == tmp_path / "_build"
     assert "Generated" in result.output
 
 
@@ -175,7 +176,8 @@ def test_configure_auto_detects_ninja_when_no_backend_markers_exist(tmp_path, mo
     result = _invoke_configure(config_path)
 
     assert result.exit_code == 0
-    assert generate_calls["build_dir"] == Path("_build")
+    # A relative --build-dir is anchored to the project, not the process cwd.
+    assert generate_calls["build_dir"] == tmp_path / "_build"
     assert "Auto-detected backend: ninja" in result.output
 
 

--- a/tests/ebuild/test_package_registry.py
+++ b/tests/ebuild/test_package_registry.py
@@ -1,5 +1,8 @@
+import pytest
+
 from ebuild.packages.recipe import PackageRecipe
 from ebuild.packages.registry import PackageRegistry
+from ebuild.packages.resolver import PackageResolver, ResolveError
 
 
 def make_recipe(version: str) -> PackageRecipe:
@@ -24,3 +27,91 @@ def test_list_all_versions_uses_numeric_version_order():
         "1.9.0",
         "1.10.0",
     ]
+
+
+# ── Out-of-format versions must not crash the registry ──────
+#
+# The numeric ordering key introduced for list_all_versions() parsed every
+# dot-separated component with int(). Versions that are not purely numeric --
+# including "v2.9.3", the upstream tag form recipes/littlefs.yaml already
+# downloads -- raised ValueError from get(), list_packages() and
+# list_all_versions() alike.
+
+OUT_OF_FORMAT_VERSIONS = [
+    "v2.9.3",       # upstream git tag, as used by recipes/littlefs.yaml's URL
+    "1.2.13-1",     # distribution revision
+    "3.6.0-rc1",    # prerelease
+    "1.0.0+build2",  # build metadata
+]
+
+
+@pytest.mark.parametrize("version", OUT_OF_FORMAT_VERSIONS)
+def test_registry_lookups_do_not_crash_on_out_of_format_version(version):
+    registry = PackageRegistry()
+    registry._register(make_recipe(version))
+
+    assert registry.get("demo").version == version
+    assert [r.version for r in registry.list_packages()] == [version]
+    assert [r.version for r in registry.list_all_versions("demo")] == [version]
+
+
+def test_numeric_release_is_preferred_over_out_of_format_sibling():
+    """A plain numeric release must win over a prerelease of the same number."""
+    registry = PackageRegistry()
+    registry._register(make_recipe("3.6.0-rc1"))
+    registry._register(make_recipe("3.6.0"))
+
+    assert registry.get("demo").version == "3.6.0"
+
+
+def test_out_of_format_versions_order_deterministically():
+    registry = PackageRegistry()
+    for version in ("1.9.0", "v2.9.3", "1.10.0", "1.2.13-1"):
+        registry._register(make_recipe(version))
+
+    ordered = [r.version for r in registry.list_all_versions("demo")]
+
+    # Out-of-format versions rank below every numeric one; numeric versions
+    # keep the ordering guaranteed by
+    # test_list_all_versions_uses_numeric_version_order.
+    assert ordered == ["1.2.13-1", "v2.9.3", "1.9.0", "1.10.0"]
+
+
+def test_one_out_of_format_recipe_does_not_hide_valid_packages():
+    registry = PackageRegistry()
+    registry._register(
+        PackageRecipe(
+            name="littlefs",
+            version="v2.9.3",
+            url="https://example.com/littlefs.tar.gz",
+        )
+    )
+    registry._register(
+        PackageRecipe(
+            name="zlib",
+            version="1.3.1",
+            url="https://example.com/zlib.tar.gz",
+        )
+    )
+
+    assert sorted(r.name for r in registry.list_packages()) == ["littlefs", "zlib"]
+
+
+def test_missing_package_raises_resolve_error_not_value_error():
+    """The resolver's not-found message enumerates the registry.
+
+    With an out-of-format recipe registered, building that message used to
+    raise ValueError, replacing the actionable ResolveError with a traceback.
+    """
+    registry = PackageRegistry()
+    registry._register(
+        PackageRecipe(
+            name="littlefs",
+            version="v2.9.3",
+            url="https://example.com/littlefs.tar.gz",
+        )
+    )
+    resolver = PackageResolver(registry)
+
+    with pytest.raises(ResolveError, match="absent_package"):
+        resolver.resolve([{"name": "absent_package", "version": None}])


### PR DESCRIPTION
## Summary

Three independent correctness fixes, one commit each. They touch unrelated code but share a theme: **eBuild doing something other than what the project declared, without saying so.**

- **Fix 1** — `ebuild build` could report success having built none of the declared targets.
- **Fix 2** — `--config` pointing outside the current directory broke `build` loudly and `configure` silently.
- **Fix 3** — one recipe with a non-numeric version crashed package discovery for every recipe.

Each fix has:

- a concrete reproduction with observed output,
- a minimal, narrowly-scoped change,
- regression tests **observed failing against the unfixed code first**, per `TESTING.md`,
- a `CHANGELOG.md` entry under `[Unreleased]/Fixed`.

**Totals:** 7 files changed, +735 / −17, **+41 regression tests**.

<br>

## Problems addressed

### 1. Declared targets overridden by backend auto-detection

**Issue**

- A `build.yaml` declaring `targets:` was ignored whenever the project directory also contained an external build-system marker file.
- eBuild ran the external tool instead, built none of the declared targets, produced no build directory — and exited **0** with `Build completed successfully`.
- Reproduced for all five marker types: `CMakeLists.txt`, `meson.build`, `Cargo.toml`, `Makefile`, `Kconfig`.

**Reproduction**

```console
$ cat build.yaml          # declares one executable target "app"
$ ls                      # build.yaml, src/, Makefile  (Makefile only holds "make flash")
$ ebuild build
[info] Auto-detected backend: make
   Using make backend...
   Building (make)...
[ok] Build completed successfully (make).
$ echo $?
0
$ ls _build
ls: _build: No such file or directory
```

**Impact**

- A silent wrong result — CI goes green and the artifacts are simply absent.
- The trigger is ordinary, not exotic:
  - a `Makefile` holding `make flash` / `make openocd` helpers is normal in embedded repositories;
  - a `CMakeLists.txt` belonging to one subcomponent is normal in any mixed tree.
- Adding either file to a working eBuild project silently stops it being built, with no warning and no non-zero exit to catch it.

**Root cause**

- `detect_backend(source_dir)` receives **only a path**. It inspects the filesystem and cannot see `build.yaml`, so a declared target list cannot influence it.
- `_resolve_backend_request` accepted its answer unconditionally.
- `build` then routed on `if resolved_backend != "ninja" or not cfg.targets:`, which sends the `(external backend, has targets)` combination into the dispatcher.
- Nothing raises, because from the dispatcher's point of view nothing is wrong: it was handed `make` and it ran `make` correctly.

<br>

### 2. Out-of-tree `--config` build path inconsistency

**Issue**

- `ebuild build --config <subdir>/build.yaml` failed.
- `ebuild configure --config <subdir>/build.yaml` reported success while writing its output where a later build would not look.

**Reproduction**

```console
$ ebuild build --config myproj/build.yaml
   Generating build.ninja in _build/...
[ok] Generated _build/build.ninja
[ok] Generated _build/compile_commands.json
   Invoking ninja...
ninja: error: loading '_build/build.ninja': No such file or directory
[error] Build failed.
$ echo $?
1
```

The output contradicts itself in adjacent lines. Two controls confirmed the diagnosis:

- an **absolute** `--build-dir` succeeded;
- running from **inside** the project succeeded.

**Impact**

- `--config` is unusable for any out-of-tree invocation — the monorepo and CI case.
- The `configure` half is worse than the `build` half: `build` fails loudly, but `configure` reports success and leaves an inconsistent tree, so the failure surfaces later and somewhere else.
- Secondary consequence: with a cwd-relative build directory, **two projects built from one working directory share a single `./_build`** and overwrite each other's `build.ninja` and objects.

**Root cause**

- One relative path, two different bases.
- `NinjaBackend.generate()` created and reported the build directory relative to the **process** working directory.
- ninja was launched with `cwd=cfg.source_dir` — necessary, so `build.yaml`'s relative source paths resolve — and given a **relative** `-f`, which it therefore resolved against the project.
- The two bases coincide **exactly** when the working directory is the project directory: the documented golden path, and the only case the committed examples exercise.

<br>

### 3. Package registry crashes on non-numeric versions

**Issue**

- Version ordering parsed every dot-separated component with `int()`.
- `get()`, `list_packages()` and `list_all_versions()` all raised `ValueError` for any version that is not purely numeric.

**Reproduction**

```console
$ ls recipes/            # zlib.yaml (1.3.1), littlefs.yaml (v2.9.3)
$ ebuild list-packages
...
ValueError: invalid literal for int() with base 10: 'v2'
$ echo $?
1
```

The valid `zlib` recipe was not listed either. Separately, resolving a **missing** package against that registry raised `ValueError` instead of `ResolveError`.

**Impact**

- One out-of-format recipe breaks package discovery for **every** package, not just its own.
- The trigger is already present in this repository: `recipes/littlefs.yaml` downloads `.../archive/refs/tags/v2.9.3.tar.gz`, so a contributor copying that upstream tag into `version:` hits it immediately.
- The same failure occurs for:
  - prereleases — `3.6.0-rc1` (a form mbedtls publishes),
  - distribution revisions — `1.2.13-1`,
  - SemVer build metadata — `1.0.0+build2`.
- It also damaged an **unrelated error path**: `PackageResolver`'s "package not found" message enumerates the registry to report what *is* available — so the diagnostic meant to help you was the thing that crashed.

**Root cause**

- `[int(x) for x in v.split('.')]` used as a sort key, duplicated verbatim at three call sites, so all three failed identically.

<br>

## What changed

### Fix 1 — `ebuild/cli/commands.py` (22 lines in `_resolve_backend_request`)

- When the backend was **auto-detected** and `cfg.targets` is non-empty, select the ninja backend and log the substitution, naming both opt-outs.
- **Explicit backends still win.** `backend:` in `build.yaml` or `--backend` on the command line bypasses this branch entirely, so a project can keep both a target list and an external build.
- **`detect_backend()` is deliberately unchanged.** It takes only a path and its ten tests assert pure filesystem probing; the targets-aware decision belongs in the CLI resolution layer, which already has `cfg`.

### Fix 2 — `ebuild/cli/commands.py` (one helper + four call sites)

- New `_resolve_build_dir()`:
  - an absolute `--build-dir` is returned unchanged;
  - a relative one resolves against the directory containing `build.yaml`, **as an absolute path**.
- **Why absolute and not merely project-relative:** a project-relative path is still re-interpreted by ninja running in `cfg.source_dir`, so `--config myproj/build.yaml` yields `myproj/_build` and ninja looks for `myproj/myproj/_build/build.ninja`. Absolute is the only form that means the same thing to the process writing the tree and the ninja reading it, and it keeps `build.ninja` independent of the directory it was generated from.
- **Why project-anchored and not cwd-anchored** — this follows what the repository already assumes:
  - the committed examples keep `_build/` beside each `build.yaml`;
  - README and `demo.md` both walk through that layout;
  - `compile_commands.json` already records `directory` as the source directory with build-dir-relative outputs;
  - it also stops two projects sharing one `./_build`.
- Applied to the four commands that pair `--config` with `--build-dir` and feed the ninja or package path: **`build`, `configure`, `install`, `test`**.
- `_run_native_tests` gains the `cwd` its own comment already claimed it matched `ebuild build` on.
- New `_shown()` helper prints build paths relative to the working directory where possible, so **the in-project output documented in `demo.md` is byte-identical** and no documentation change was needed.

### Fix 3 — `ebuild/packages/registry.py` (one helper replacing three inline keys)

- New `_version_sort_key()`:
  - dot-separated integers keep **exact numeric ordering**, so `1.10.0` still sorts above `1.9.0`;
  - anything else is **not interpreted** — ranked below every numeric version and ordered lexicographically among its peers.
- Ranking out-of-format versions *below* is deliberate: with `3.6.0` and `3.6.0-rc1` both registered, `get()` returns the plain release rather than the prerelease.
- **Deliberately not a SemVer parser.** The recipe format documents no version grammar, every bundled recipe uses dot-separated integers, and inventing prerelease semantics would exceed the defect.
- No dependency added. No validation added — rejecting `v2.9.3` at load time would break a legitimate recipe rather than fix anything.
- `resolver.py` needed no change: it failed only through `list_packages()`, so fixing the registry fixes the error path too.

<br>

## Test results — before and after

### Regression suites (each observed failing against the unfixed code first)

| Suite | Tests | **Before the fix** | **After the fix** |
|---|---|---|---|
| `tests/ebuild/test_backend_targets_precedence.py` *(new)* | 25 | **10 failed** / 15 passed | **25 passed** |
| `tests/ebuild/test_build_dir_resolution.py` *(new)* | 8 | **6 failed** / 2 passed | **8 passed** |
| `tests/ebuild/test_package_registry.py` *(+8)* | 9 | **8 failed** / 1 passed | **9 passed** |

In each suite the tests that pass in *both* states are the deliberate preservation guards — explicit backends still win, marker-only projects are unaffected, in-project and absolute build dirs are unchanged, and PR #51's ordering test is unmodified.

### Existing tests covering the modified components

| Files | Result |
|---|---|
| `test_cli_backend_resolution.py`, `tests/ebuild/test_dispatch.py`, `tests/unit/test_dispatch.py`, `test_golden_path_commands.py`, `test_build_failure_output.py`, `test_package_fetcher.py`, `test_resolver.py` | **99 passed, 0 failed** |

### Full suite

| | Command | Result |
|---|---|---|
| **Before** (all changes stashed) | `pytest tests/` | **290 passed, 1 failed** |
| **After** | `pytest tests/` | **331 passed, 1 failed** |

`290 + 41 new tests = 331.`

### The suite is not fully green — before or after

One test fails in **both** states:

```
tests/ebuild/test_ninja_backend.py::test_shared_library_uses_shared_link_rule
```

- It is **pre-existing and macOS-specific.** It asserts `command = $cc -shared`, while `_shared_flag()` correctly emits `-dynamiclib` on Darwin — so the implementation is right and the assertion is platform-blind.
- It is **unrelated to these changes and deliberately left untouched**; fixing it belongs in its own PR.
- I compared the failing-test **identifier sets** before and after: **identical**. No failure was introduced or removed.

### Validation beyond the unit tests

- **Real example builds.** `examples/hello_world` and `examples/multi_target` were copied to a scratch directory and built **both from inside the project and out-of-tree**; binaries were produced and executed successfully. In-project console output is byte-identical to the block documented in `demo.md`.
- **Lint — zero new findings.** `flake8 --select=E,F,W --ignore=E501` is clean (exit 0) on all new/changed test files. The 9 findings on the two modified source files are pre-existing with identical codes at baseline (six `E241` in `generate_boot`, three `E121`/`E126` from PR #51's continuation indentation).
- **Line endings preserved.** `ebuild/cli/commands.py` has mixed line endings (1849 CRLF of 2410 lines). Every edit was made at byte level with per-site line-ending detection; the CRLF count is identical before and after. `git diff --check` reports four "trailing whitespace" warnings, which a control test confirmed are the CR of pre-existing CRLF lines, not whitespace introduced here.
- **Not run:** `mypy` and coverage measurement locally (CI runs mypy with `continue-on-error: true`); Linux and Windows legs.

<br>

## Relationship to previous work

- **PR #46 (commit `04f4951`)** addressed the case where an *unsupported* backend reached `BackendDispatcher`; its commit message records the symptom as *"both methods silently did nothing, and the CLI then printed 'Build completed successfully' with exit code 0."* It added `RuntimeError` branches so that case fails loudly.
  → While reviewing that path I found a separate unresolved case: a **supported** but incorrectly auto-detected backend could still override declared targets, and it does not raise because the dispatcher is doing its job correctly. The silent-success symptom that change eliminated for one cause remained reachable through another.

- **PR #40 (commit `f4c50c0`)** centralised backend resolution into `_resolve_backend_request` and added `tests/ebuild/test_cli_backend_resolution.py`. Fix 1 lands in that helper.
  → I verified beforehand that no existing test encoded the old precedence: across `test_cli_backend_resolution.py`, `tests/ebuild/test_dispatch.py` and `tests/unit/test_dispatch.py`, **no test combines a non-empty `targets:` list with a marker file** (`test_cmake_takes_priority_over_makefile` encodes marker-versus-marker priority).

- **Commit `b56bf9d`** ("fix: ninja backend library linking, cwd path, and project generator duplication") addressed relative **source** path resolution: before it, `ninja -C <build_dir>` ran inside the build directory and resolved `build.yaml`'s relative sources against it. The commit changed the invocation to `ninja -f <build_dir>/build.ninja` with `cwd=cfg.source_dir`, which fixes source resolution and works. *I could find no pull request merge referencing `b56bf9d` in the repository history, so I am not attributing a PR number to it.*
  → While reviewing that path I found the `-f` argument and the build output paths are relative as well, and are now read against that new working directory, while the Python side still resolved against the process working directory. The two therefore agree only when the working directory is the project directory — which is the only case the `examples/*/_build/` artifacts committed in that same change exercise.

- **PR #51 (commit `03afa1a`)** addressed **version ordering** in `list_all_versions()`, changing `sorted(versions.keys())` to a numeric key and adding the registry's first test (`1.2.0 < 1.9.0 < 1.10.0`). That fixed a real bug — lexicographic sort ranks `1.10.0` below `1.9.0`.
  → While reviewing that path I found the numeric key has no tolerance for non-integer components, and its test uses only purely numeric versions, so the fragility was never exercised. That change propagated an existing key (introduced in `7a1cab3`) to a third call site rather than introducing it. Fix 3 **preserves its ordering guarantee — its test is unmodified and still passes** — and adds the missing tolerance at all three sites.

- **PR #57 (commit `02c48ce`, `fix/resolver-version-pinning`)** addressed **version selection** in `resolver.py`, collecting explicit pins before walking the graph so resolution is order-independent. It does not touch parsing or ordering, and is distinct from this change: *selection* decides which version is wanted, *ordering* decides how versions compare.

All of these were legitimate improvements that closed the failure modes they targeted. What is fixed here are the adjacent cases that remained outside their scope.

<br>

## Additional considerations / limitations

- **Validated on macOS/arm64 only.** Linux and Windows were not validated locally. `Path.is_absolute()` and `Path.resolve()` behave differently on Windows for drive-relative paths such as `C:foo`; the `windows-2022` and `ubuntu-22.04` CI legs are the check. `TASKS.md` T-002 already records an open Windows Ninja path defect, so that platform has known path issues independent of this change.

- **The pre-existing macOS failure remains** (`test_shared_library_uses_shared_link_rule`) and was deliberately not fixed — it belongs in its own change.

- **Fix 1 is a behaviour change.** A project relying on the old precedence — an unused `targets:` list plus a real external build — will now take the ninja path. The logged message names the one-line opt-out (`backend:` or `--backend`). I judged an explicit, logged, reversible override better than continuing to silently discard a declaration.

- **Fix 2 leaves `clean`, `pipeline`, `system` and `firmware` alone.** None launches ninja from a different directory or shares the package cache, so none exhibits the defect. One consequence follows: after an out-of-tree build, `ebuild clean` run from the working directory will not find the project's `_build`. That is pre-existing — `clean` takes no `--config`, so it has no project to anchor to — but this change makes it easier to encounter.

- **Fix 3's version-ordering contract is deliberately limited.** The ordering of out-of-format versions is a documented choice, not a specification: `1.2.13-1` sorts *below* `1.2.13`, which is arguably wrong under Debian conventions. Such versions are outside the format the registry claims to order, and a fuller treatment should follow a written version contract rather than inferred semantics.

<br>

## Scope

Other findings from a broader read of the repository were **intentionally not bundled into this PR**:

- shared-library and transitive static-archive linking (`depends:` links only *direct* `static_library` targets);
- toolchain resolution (`compiler: clang` currently resolves to `cc = gcc`);
- malformed-recipe YAML escaping `PackageRegistry.scan()`'s skip logic;
- missing `-fPIC` for `shared_library` targets (and the unreferenced `_PIC_FLAGS` constant);
- several `ebuild add` and `configure` error paths that emit raw tracebacks;
- the macOS test expectation noted above.

Each is reproducible and worth fixing, and each deserves its own reproduction, tests and review rather than turning three focused fixes into an unrelated refactor.

<br>

## Commits

| Commit | Subject |
|---|---|
| `b345bde` | `fix(packages): tolerate non-numeric recipe versions when ordering` |
| `bba6f75` | `fix(cli): don't let backend auto-detection override declared targets` |
| `d1a752e` | `fix(cli): anchor a relative --build-dir to the project` |

All three are DCO signed-off. Each fix is self-contained and independently revertable, and the history is bisectable — commit 2 was verified to pass the full suite on its own (323 passed, same single pre-existing failure).
