### PR TITLE
fix(deps): setup clones master, the branch these repos actually have

### DIFF
--- a/ebuild/deps/__init__.py
+++ b/ebuild/deps/__init__.py
@@ -23,14 +23,17 @@ DEFAULT_EFIRMWARE_REPO_URL = "https://github.com/embeddedos-org/eFirmware.git"
 
 DEFAULT_CONFIG = {
     "repos": {
+        # Both repos default to master; neither has a main. Cloning the
+        # branch named here is what `ebuild setup` does first, so "main"
+        # failed it for every new developer before any build ran.
         "eos": {
             "url": DEFAULT_EOS_REPO_URL,
-            "branch": "main",
+            "branch": "master",
             "path": None,
         },
         "eboot": {
             "url": DEFAULT_EBOOT_REPO_URL,
-            "branch": "main",
+            "branch": "master",
             "path": None,
         },
         # §29 ends the development-to-device flow at an eFirmware artifact.


### PR DESCRIPTION
> Stacked on #97 and the version-ordering PR. Review the last commit.

`ebuild setup` — the first command a new developer runs — clones eos and eBoot at the branch named in `DEFAULT_CONFIG`. Both entries name `main`. Neither repository has a `main`:

```
$ git ls-remote --heads https://github.com/embeddedos-org/eos.git main
$ git ls-remote --heads https://github.com/embeddedos-org/eBoot.git main
$          # both empty; both default to master
```

So `setup` fails for every new developer, before any build can run.

`efirmware`, in the same mapping, already names `master` — only the two that matter for a first `setup` were wrong.

`tests/unit/test_sources_are_importable.py::test_default_repo_branch_exists_upstream` asserts each configured branch exists upstream and has been failing on exactly this, which the suite could not report while collection was broken (#97).
