### PR TITLE
Fix board_capacity dropping known values on partial override

### DIFF
--- a/ebuild/build/footprint.py
+++ b/ebuild/build/footprint.py
@@ -201,25 +201,29 @@ def measure(artifact: Path, size_tool: Optional[str] = None) -> Footprint:
 
 
 def board_capacity(board: Optional[str],
-                   board_config: Optional[dict] = None
-                   ) -> Tuple[Optional[int], Optional[int]]:
-    """Flash and RAM capacity for a board, or (None, None) when unknown.
+                  board_config: Optional[dict] = None
+                  ) -> Tuple[Optional[int], Optional[int]]:
+   """Flash and RAM capacity for a board, or (None, None) when unknown.
 
-    A project's own board YAML wins over the reference table: `memory.flash_size`
-    and `memory.ram_size` are what the hardware descriptions in `hardware/board/`
-    already use.
-    """
-    if board_config:
-        memory = board_config.get("memory") or {}
-        flash = _as_bytes(memory.get("flash_size"))
-        ram = _as_bytes(memory.get("ram_size"))
-        if flash or ram:
-            return flash, ram
-    if board:
-        found = _REFERENCE_CAPACITY.get(board.lower())
-        if found:
-            return found
-    return None, None
+
+   A project's own board YAML wins over the reference table: `memory.flash_size`
+   and `memory.ram_size` are what the hardware descriptions in `hardware/board/`
+   already use.
+   """
+   reference = _REFERENCE_CAPACITY.get(board.lower()) if board else None
+   if board_config:
+       memory = board_config.get("memory") or {}
+       flash = _as_bytes(memory.get("flash_size"))
+       ram = _as_bytes(memory.get("ram_size"))
+       if flash or ram:
+           if flash is None and reference:
+               flash = reference[0]
+           if ram is None and reference:
+               ram = reference[1]
+           return flash, ram
+   if reference:
+       return reference
+   return None, None
 
 
 def _as_bytes(value) -> Optional[int]:

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,8 +17,6 @@ markers =
     integration: end-to-end tests spanning multiple repos
     cross_repo: cross-repo integration tests requiring sibling repos
     qemu: tests requiring QEMU emulator (skipped if QEMU not installed)
-    cross_repo: cross-repo integration tests requiring sibling repos
-    qemu: tests requiring QEMU emulator (skipped if QEMU not installed)
     needs_yaml: tests that import modules requiring pyyaml
 
 # ── Output ───────────────────────────────────────────────────

--- a/tests/unit/test_footprint.py
+++ b/tests/unit/test_footprint.py
@@ -153,6 +153,17 @@ class TestBoardCapacity:
     def test_a_board_config_without_memory_falls_back(self):
         assert board_capacity("stm32f4", {"board_name": "x"})[0] == 1024 * 1024
 
+    def test_a_partial_override_fills_the_rest_from_the_reference_part(self):
+       """A board YAML that only overrides RAM (say, because it was fitted
+       with extra SRAM) should not lose the reference flash figure for the
+       same part."""
+       cfg = {"memory": {"ram_size": 320 * 1024}}
+       assert board_capacity("stm32f4", cfg) == (1024 * 1024, 320 * 1024)
+
+
+       cfg = {"memory": {"flash_size": "0x40000"}}
+       assert board_capacity("stm32f4", cfg) == (262144, 192 * 1024)
+
 
 class TestReport:
     def test_percentages_appear_only_with_a_known_capacity(self):


### PR DESCRIPTION
## Summary
- `board_capacity()` in `ebuild/build/footprint.py` discarded the reference-table
  value for whichever of flash/ram a board YAML didn't explicitly override,
  instead of falling back to it. A board config that set only `ram_size`, for
  example, would report flash as unknown even though the board name matched
  an entry in `_REFERENCE_CAPACITY`.
- Missing fields are now backfilled from the reference table when at least one
  field is overridden, so partial overrides no longer lose known data.
- Removed a duplicate pair of marker declarations (`cross_repo`, `qemu`) in
  `pytest.ini`, left over from a prior merge.

## Test plan
- [x] Added `test_a_partial_override_fills_the_rest_from_the_reference_part`
      covering both partial-override directions (flash-only, ram-only)
- [x] `pytest -q` — 562 passed
- [x] Independent code-review pass — no findings