### PR TITLE
fix Windows installer Scripts path detection

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -52,10 +52,10 @@ if %ERRORLEVEL% equ 0 (
 )
 
 REM Step 4: Find the Scripts directory and add to PATH
-for /f "delims=" %%i in ('%PYTHON% -c "import site; print(site.getusersitepackages().replace(chr(92)+chr(39)lib'+chr(92)+'site-packages', chr(92)+'Scripts'))"') do set SCRIPTS_DIR=%%i
+for /f "delims=" %%i in ('%PYTHON% -c "import sysconfig; print(sysconfig.get_path('scripts', scheme='nt_user'))"') do set SCRIPTS_DIR=%%i
 
 if not exist "%SCRIPTS_DIR%\ebuild.exe" (
-    for /f "delims=" %%i in ('%PYTHON% -c "import sys; import os; print(os.path.join(os.path.dirname(sys.executable), chr(39)Scripts'))"') do set SCRIPTS_DIR=%%i
+    for /f "delims=" %%i in ('%PYTHON% -c "import sysconfig; print(sysconfig.get_path('scripts'))"') do set SCRIPTS_DIR=%%i
 )
 
 if exist "%SCRIPTS_DIR%\ebuild.exe" (

--- a/install.bat
+++ b/install.bat
@@ -52,10 +52,10 @@ if %ERRORLEVEL% equ 0 (
 )
 
 REM Step 4: Find the Scripts directory and add to PATH
-for /f "delims=" %%i in ('%PYTHON% -c "import sysconfig; print(sysconfig.get_path('scripts', scheme='nt_user'))"') do set SCRIPTS_DIR=%%i
+for /f "delims=" %%i in ('%PYTHON% -c "import sysconfig; print(sysconfig.get_path('scripts'))"') do set SCRIPTS_DIR=%%i
 
 if not exist "%SCRIPTS_DIR%\ebuild.exe" (
-    for /f "delims=" %%i in ('%PYTHON% -c "import sysconfig; print(sysconfig.get_path('scripts'))"') do set SCRIPTS_DIR=%%i
+    for /f "delims=" %%i in ('%PYTHON% -c "import sysconfig; print(sysconfig.get_path('scripts', scheme='nt_user'))"') do set SCRIPTS_DIR=%%i
 )
 
 if exist "%SCRIPTS_DIR%\ebuild.exe" (

--- a/tests/unit/test_windows_installer.py
+++ b/tests/unit/test_windows_installer.py
@@ -1,0 +1,30 @@
+﻿from pathlib import Path
+
+
+INSTALLER = Path(__file__).resolve().parents[2] / "install.bat"
+
+
+def test_embedded_python_commands_are_syntactically_valid():
+    """Python snippets embedded in the Windows installer must be valid."""
+    content = INSTALLER.read_text(encoding="utf-8")
+    commands = []
+
+    for line in content.splitlines():
+        marker = '-c "'
+
+        if marker not in line:
+            continue
+
+        start = line.index(marker) + len(marker)
+        end = line.rfind('"')
+
+        assert end > start, (
+            f"Malformed embedded Python command in install.bat: {line}"
+        )
+
+        commands.append(line[start:end])
+
+    assert commands, "No embedded Python commands found in install.bat"
+
+    for command in commands:
+        compile(command, "<install.bat>", "exec")

--- a/tests/unit/test_windows_installer.py
+++ b/tests/unit/test_windows_installer.py
@@ -1,30 +1,94 @@
-﻿from pathlib import Path
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+import pytest
 
 
 INSTALLER = Path(__file__).resolve().parents[2] / "install.bat"
 
+BATCH_COMMAND_PATTERN = re.compile(
+    r'^\s*for /f "delims=" %%i in \(\''
+    r'%PYTHON% -c "(?P<python>.+)"\'\) '
+    r'do set SCRIPTS_DIR=%%i\s*$'
+)
 
-def test_embedded_python_commands_are_syntactically_valid():
-    """Python snippets embedded in the Windows installer must be valid."""
+
+def _installer_python_commands():
     content = INSTALLER.read_text(encoding="utf-8")
-    commands = []
 
-    for line in content.splitlines():
-        marker = '-c "'
+    return [
+        line
+        for line in content.splitlines()
+        if '-c "' in line
+    ]
 
-        if marker not in line:
-            continue
 
-        start = line.index(marker) + len(marker)
-        end = line.rfind('"')
+def test_embedded_python_commands_are_well_formed():
+    """Installer Python commands must have valid batch and Python syntax."""
+    lines = _installer_python_commands()
 
-        assert end > start, (
-            f"Malformed embedded Python command in install.bat: {line}"
+    assert lines, "No embedded Python commands found in install.bat"
+
+    for line in lines:
+        match = BATCH_COMMAND_PATTERN.fullmatch(line)
+
+        assert match is not None, (
+            f"Malformed FOR /F Python command in install.bat: {line}"
         )
 
-        commands.append(line[start:end])
-
-    assert commands, "No embedded Python commands found in install.bat"
-
-    for command in commands:
+        command = match.group("python")
         compile(command, "<install.bat>", "exec")
+
+
+@pytest.mark.skipif(
+    os.name != "nt",
+    reason="Windows cmd.exe validation",
+)
+def test_embedded_python_commands_execute_in_cmd(tmp_path):
+    """The complete FOR /F commands must execute successfully in cmd.exe."""
+    lines = _installer_python_commands()
+
+    assert len(lines) == 2
+
+    batch_file = tmp_path / "validate_installer_commands.bat"
+
+    script = "\r\n".join(
+        [
+            "@echo off",
+            "setlocal",
+            f'set "PYTHON={sys.executable}"',
+            'set "SCRIPTS_DIR="',
+            lines[0],
+            "if not defined SCRIPTS_DIR exit /b 11",
+            "echo FIRST=%SCRIPTS_DIR%",
+            'set "SCRIPTS_DIR="',
+            lines[1],
+            "if not defined SCRIPTS_DIR exit /b 12",
+            "echo SECOND=%SCRIPTS_DIR%",
+            "endlocal",
+        ]
+    )
+
+    batch_file.write_text(
+        script,
+        encoding="utf-8",
+        newline="",
+    )
+
+    result = subprocess.run(
+        ["cmd.exe", "/d", "/c", str(batch_file)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        f"cmd.exe failed\nSTDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )
+
+    assert "FIRST=" in result.stdout
+    assert "SECOND=" in result.stdout


### PR DESCRIPTION
## Summary

Fixes broken Windows `Scripts` directory detection in `install.bat`.

The original embedded Python commands were syntactically invalid, causing the `FOR /F` probes to produce no output and leaving `SCRIPTS_DIR` unset.

This PR replaces the manual path construction with Python's standard `sysconfig` API, checks the active Python environment first, and falls back to the per-user Scripts directory when necessary.

Regression coverage now validates both the embedded Python and the surrounding Windows batch syntax, including execution through the real `cmd.exe`.

## Type of Change

* [ ] feat — New feature
* [x] fix — Bug fix
* [ ] docs — Documentation only
* [ ] style — Formatting, no code change
* [ ] refactor — Code restructuring without behavior change
* [x] test — Add or fix tests
* [ ] build — Build system or dependency changes
* [ ] ci — CI/CD pipeline changes
* [ ] perf — Performance improvement

## Changes

* Replaced malformed embedded Python path-detection expressions in `install.bat` with `sysconfig.get_path()`.
* Changed the probe order to check the active Python environment's Scripts directory first.
* Added the per-user `nt_user` Scripts directory as the fallback.
* Strengthened the regression test to validate the complete `FOR /F` batch command structure.
* Added Windows-only validation that executes both installer commands through `cmd.exe`.
* Removed the UTF-8 BOM from `tests/unit/test_windows_installer.py`.

## Testing

* [ ] Unit tests pass (`ctest --test-dir build --output-on-failure`)
* [ ] Integration tests pass
* [x] Manual testing performed
* [x] New tests added for new functionality

### Focused regression tests

Run on Windows with Python 3.14.6:

```text
tests/unit/test_windows_installer.py::test_embedded_python_commands_are_well_formed PASSED
tests/unit/test_windows_installer.py::test_embedded_python_commands_execute_in_cmd PASSED

2 passed
```

### Lint validation

```text
python -m flake8 tests/unit/test_windows_installer.py
```

Result: no issues reported.

### Windows `cmd.exe` validation

The installer detection logic was also exercised through the actual Windows command interpreter.

```text
USER_SCRIPTS=C:\Users\dhana\AppData\Roaming\Python\Python314\Scripts

FINAL_SCRIPTS=C:\Users\dhana\OneDrive\Desktop\project\ebuild-windows-installer-assessment\.venv\Scripts

EBUILD_FOUND=YES
```

The active virtual-environment Scripts directory was resolved successfully and `ebuild.exe` was found.

### Full repository test suite

I also attempted to run the complete repository pytest suite.

Collection is currently blocked by a pre-existing syntax error in the unrelated file:

```text
ebuild/build/dispatch.py
```

That file is unchanged by this PR, so I kept this fix scoped to the Windows installer issue.

## Pre-Submission Checklist

* [ ] Code compiles without warnings (`-Wall -Wextra -Werror` for C)
* [ ] All existing tests pass
* [x] New tests added for new functionality
* [ ] Documentation updated if API changed
* [ ] Commit messages follow `<type>(<scope>): <description>` convention
* [ ] Branch is rebased on latest master

## Related Issues

N/A

## Screenshots / Logs

<img width="1472" height="136" alt="Windows installer validation" src="https://github.com/user-attachments/assets/0f7c5c46-77bd-4063-9c43-540c021444a2" />

## Additional Notes

Validated on Windows with Python 3.14.6 using both an active virtual environment and the per-user Python Scripts path.

The implementation remains intentionally scoped to Windows Scripts-directory detection. No unrelated source files were modified.
