### PR TITLE
fix: derive SDK toolchain from detected profile

### DIFF
--- a/core/eos/docs/three-way-alignment.md
+++ b/core/eos/docs/three-way-alignment.md
@@ -8,7 +8,7 @@ This document tracks alignment between all three EoS components to ensure they r
 
 | Dimension | eos | eboot | ebuild | Status |
 |-----------|-----|-------|--------|--------|
-| Board definitions | 25 YAML files in `eos/boards/` | 25 board ports in `eboot/boards/` | `MCU_TO_EBOOT_BOARD` + `EOS_BOARD_MAP` in project generator | ✅ Aligned |
+| Board definitions | 84 board YAMLs in `eos/boards/` (upstream) | 83 board dirs / 138 `eboot_add_board()` calls in `eboot/boards/` (upstream, pinned rev) | `TARGET_ARCH` 14 + `MCU_TO_EBOOT_BOARD` 138 in `ebuild/sdk_generator.py` | ⚠️ Unverified: 84 vs 83 vs 14/138 — three inventories describe the same set and nothing cross-checks them; see the resolver drift note in PR #109 |
 | Product profiles | 41 profiles in `eos/products/*.h` | — | `PRODUCT_MAP` (41 entries) in project generator | ✅ Aligned |
 | Platform enum | — | 24 `eos_platform_t` entries in `eos_hal.h` | MCU_DATABASE (100+ MCUs) in hw analyzer | ✅ Aligned |
 | Peripheral keywords | 33 HAL APIs in `hal.h` + `hal_extended.h` | — | `PERIPHERAL_KEYWORDS` (24 types) + `ComponentDB` (200+ parts) | ✅ Aligned |
@@ -118,7 +118,7 @@ Customer Input
 │     LLMClient (optional) ──► deep analysis                  │
 │                                                              │
 │  2. EosProjectGenerator                                     │
-│     MCU_TO_EBOOT_BOARD ──────────────────► eboot board dir  │
+│     MCU_TO_EBOOT_BOARD (alias of ebuild/sdk_generator.py) ► eboot board dir  │
 │     EOS_BOARD_MAP ──────────────────────► eos board YAML    │
 │     PRODUCT_MAP (41 entries) ──────────► eos product .h     │
 │     MULTICORE_MCUS ─────────────────────► multicore config  │

--- a/docs/guides/adding_a_board.md
+++ b/docs/guides/adding_a_board.md
@@ -209,7 +209,8 @@ board:
 
 ## Step 7: Add Project Generator Mapping
 
-Edit `ebuild/eos_ai/eos_project_generator.py`:
+Edit `ebuild/sdk_generator.py` (the Tier-1 table; `ebuild/eos_ai/eos_project_generator.py`
+only holds an alias importing it from there):
 
 ```python
 MCU_TO_EBOOT_BOARD = {

--- a/ebuild/cli/commands.py
+++ b/ebuild/cli/commands.py
@@ -650,7 +650,7 @@ def _run_pipeline_steps(
     from ebuild.eos_ai.eos_hw_analyzer import EosHardwareAnalyzer
     from ebuild.eos_ai.eos_config_generator import EosConfigGenerator
     from ebuild.eos_ai.eos_boot_integrator import EosBootIntegrator
-    from ebuild.sdk_generator import generate_sdk
+    from ebuild.sdk_generator import generate_sdk_from_profile
 
     configs_dir = build_dir / "configs"
     sdk_dir = build_dir / "sdk"
@@ -700,10 +700,18 @@ def _run_pipeline_steps(
         log.success("  " + name + ": " + str(path))
 
     # Step 4: Generate SDK (toolchain.cmake, environment-setup, eboot target config)
+    # Drive the SDK from the detected profile, not just the board name — otherwise
+    # any MCU absent from the small target table silently regressed to an x86_64 SDK.
     log.step("[4/6] Generating SDK...")
-    target_name = board.lower()
-    generate_sdk(target_name, str(sdk_dir))
-    log.success("  SDK generated in " + str(sdk_dir))
+    _, toolchain_ok, eboot_board = generate_sdk_from_profile(profile, str(sdk_dir), target=board)
+    if not toolchain_ok:
+        raise RuntimeError("no cross-toolchain ships for " + board + "; the SDK fell back "
+                           "to the host x86_64 compiler. Run `ebuild sdk --list`.")
+    if eboot_board is None:
+        log.warning("  no eBoot board for " + board + ": eboot/eboot_board.cmake carries a "
+                    "FATAL_ERROR; a build that needs the board will fail by name.")
+    else:
+        log.success("  SDK generated in " + str(sdk_dir))
 
     # Step 5: Copy generated headers to build include path
     log.step("[5/6] Copying headers to build include path...")

--- a/ebuild/cli/integration.py
+++ b/ebuild/cli/integration.py
@@ -611,7 +611,7 @@ def register_commands(cli_group: click.Group) -> None:
         eBoot board config for the specified hardware target.
         """
         sys.path.insert(0, str(Path(__file__).parent.parent))
-        from ebuild.sdk_generator import generate_sdk, list_targets as do_list
+        from ebuild.sdk_generator import TARGET_ARCH, generate_sdk, list_targets as do_list
 
         if list_targets:
             do_list()
@@ -621,6 +621,14 @@ def register_commands(cli_group: click.Group) -> None:
         log.info("Target: " + target)
         log.info("Output: " + output)
         sdk_dir = generate_sdk(target, output)
+        # Same gate as the pipeline path (commands.py step 4): a target outside
+        # TARGET_ARCH is a deliberate fallback (host x86_64 compiler + FATAL_ERROR
+        # eboot board), not a success. Exit non-zero instead of printing [ok].
+        if target not in TARGET_ARCH:
+            log.error("no cross-toolchain ships for " + target + "; the SDK fell back "
+                      "to the host x86_64 compiler and eboot/eboot_board.cmake carries "
+                      "a FATAL_ERROR. Run `ebuild sdk --list` for supported targets.")
+            raise SystemExit(1)
         log.success("SDK generated: " + str(sdk_dir))
 
     # Named "package-deliverable", not "package": #77 added a `package`

--- a/ebuild/eos_ai/eos_project_generator.py
+++ b/ebuild/eos_ai/eos_project_generator.py
@@ -25,6 +25,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
 from ebuild.eos_ai.eos_hw_analyzer import HardwareProfile
+from ebuild.sdk_generator import MCU_TO_EBOOT_BOARD as _MCU_TO_EBOOT_BOARD
+from ebuild.sdk_generator import board_dir_for_mcu
 
 # Default GitHub URLs for eos and eboot repositories
 DEFAULT_EOS_REPO_URL = "https://github.com/spatchava/eos.git"
@@ -96,166 +98,9 @@ class EosProjectGenerator:
         "sensor": ["services/sensor"],
     }
 
-    # Map MCU family → matching eboot board directory name
-    MCU_TO_EBOOT_BOARD: Dict[str, str] = {
-        # ARM Cortex-M/A (modern)
-        "stm32f4": "stm32f4",
-        "stm32h7": "stm32h7",
-        "stm32h743": "stm32h7",
-        "stm32mp1": "stm32mp1",
-        "nrf52": "nrf52",
-        "nrf52840": "nrf52",
-        "rpi4": "rpi4",
-        "rpi": "rpi4",
-        "raspberrypi": "rpi4",
-        "bcm2711": "rpi4",
-        "riscv64_virt": "riscv64_virt",
-        "esp32": "esp32",
-        "x86_64_efi": "x86_64_efi",
-        "imx8m": "imx8m",
-        "am64x": "am64x",
-        "am6442": "am64x",
-        "samd51": "samd51",
-        "sifive_u": "sifive_u",
-        "sifive": "sifive_u",
-        "fu740": "sifive_u",
-        "qemu_arm64": "qemu_arm64",
-        "qemuarm64": "qemu_arm64",
-        "tms570": "cortex_r5",
-        "rm57": "cortex_r5",
-        "rm46": "cortex_r5",
-        # Intel StrongARM
-        "sa110": "strongarm",
-        "sa1100": "strongarm",
-        "sa1110": "strongarm",
-        # Intel XScale
-        "pxa250": "xscale",
-        "pxa255": "xscale",
-        "pxa270": "xscale",
-        "ixp420": "xscale",
-        "ixp425": "xscale",
-        "ixp465": "xscale",
-        # Fujitsu FR-V
-        "fr400": "frv",
-        "fr450": "frv",
-        "fr500": "frv",
-        "fr550": "frv",
-        "mb93091": "frv",
-        "mb93493": "frv",
-        # Hitachi/Renesas SuperH
-        "sh7604": "sh4",
-        "sh7091": "sh4",
-        "sh7750": "sh4",
-        "sh7751": "sh4",
-        "sh7709": "sh4",
-        "sh7710": "sh4",
-        "sh7203": "sh4",
-        "sh7206": "sh4",
-        # Hitachi/Renesas H8/300H
-        "h8300h": "h8300",
-        "h8s2148": "h8300",
-        "h8s2368": "h8300",
-        "h83048": "h8300",
-        "h83069": "h8300",
-        # Intel x86
-        "i386": "x86",
-        "i486": "x86",
-        "pentium": "x86",
-        "atom": "x86",
-        "quark": "x86",
-        # MIPS
-        "mips32": "mips",
-        "mips64": "mips",
-        "mips24k": "mips",
-        "mips34k": "mips",
-        "pic32": "mips",
-        "jz4740": "mips",
-        "ar9331": "mips",
-        # Matsushita/Panasonic AM3x
-        "mn1030": "mn103",
-        "mn103s": "mn103",
-        "am33": "mn103",
-        "am34": "mn103",
-        # Motorola/NXP PowerPC
-        "mpc8xx": "powerpc",
-        "mpc5200": "powerpc",
-        "mpc5554": "powerpc",
-        "mpc8260": "powerpc",
-        "mpc8540": "powerpc",
-        "p1020": "powerpc",
-        "p2020": "powerpc",
-        "t1040": "powerpc",
-        "ppc440": "powerpc",
-        "ppc405": "powerpc",
-        # Motorola 68k / ColdFire
-        "mc68000": "m68k",
-        "mc68020": "m68k",
-        "mc68030": "m68k",
-        "mc68040": "m68k",
-        "mc68060": "m68k",
-        "mcf5206": "m68k",
-        "mcf5272": "m68k",
-        "mcf5307": "m68k",
-        "mcf5407": "m68k",
-        "mcf5475": "m68k",
-        "mcf5282": "m68k",
-        "mcf52235": "m68k",
-        "mcf54418": "m68k",
-        # NEC/Renesas V850
-        "v850": "v850",
-        "v850e": "v850",
-        "v850e2": "v850",
-        "v850es": "v850",
-        "upd70f3002": "v850",
-        "rh850": "v850",
-        # Sun/Oracle SPARC
-        "sparc": "sparc",
-        "leon3": "sparc",
-        "leon4": "sparc",
-        "ut699": "sparc",
-        "gr712rc": "sparc",
-        "erc32": "sparc",
-        "ultrasparc": "sparc",
-        # --- TI ---
-        "msp430": "msp430",
-        "tms320f28": "c28x",
-        "tms320c67": "c6000",
-        "am335x_pru": "pru",
-        # --- Renesas + Infineon ---
-        "rl78": "rl78",
-        "rx65": "rx",
-        "rx72": "rx",
-        "tc397": "tricore",
-        "tc375": "tricore",
-        "xc2267": "c166",
-        # --- FPGA ---
-        "microblaze": "microblaze",
-        "nios2": "nios2",
-        "mor1kx": "openrisc",
-        "lm32": "lm32",
-        # --- DSP ---
-        "adsp_bf": "blackfin",
-        "adsp_21": "sharc",
-        "sdm845": "hexagon",
-        "ceva_xm": "ceva",
-        "hifi5": "xtensa_hifi",
-        # --- Misc ---
-        "arc_em": "arc",
-        "stc89": "8051",
-        "efm8": "8051",
-        "esp32c3": "esp32c3",
-        "esp32s3": "esp32s3",
-        # --- Server/exotic ---
-        "ultrasparc_t": "sparc64",
-        "power9": "ppc64",
-        "loongson": "loongarch",
-        "pa87": "parisc",
-        "itanium": "ia64",
-        "alpha21": "alpha",
-        "ibm_z": "s390",
-        "etrax": "cris",
-        "csr8675": "kalimba",
-    }
+    # MCU family -> eboot board dir table lives in ebuild.sdk_generator (Tier-1);
+    # this alias keeps the Tier-3 consumer depending down, not up.
+    MCU_TO_EBOOT_BOARD = _MCU_TO_EBOOT_BOARD
 
     # eboot core files that are always needed
     EBOOT_CORE_ALWAYS: List[str] = [
@@ -818,12 +663,8 @@ class EosProjectGenerator:
         return "rtos"
 
     def _resolve_eboot_board(self, profile: HardwareProfile) -> str:
-        """Map MCU → eboot board directory name."""
-        mcu = (profile.mcu or "").lower()
-        for prefix, board in self.MCU_TO_EBOOT_BOARD.items():
-            if mcu.startswith(prefix):
-                return board
-        return ""
+        """Map MCU → eboot board directory name (longest prefix wins)."""
+        return board_dir_for_mcu(profile.mcu) or ""
 
     def _resolve_eos_board(self, profile: HardwareProfile) -> str:
         """Map MCU family → eos board YAML filename."""

--- a/ebuild/sdk_generator.py
+++ b/ebuild/sdk_generator.py
@@ -4,6 +4,243 @@
 import argparse
 import json
 import os
+import re
+
+# MCU family prefix -> eboot board directory name (Tier-1 source of truth;
+# EosProjectGenerator imports it from here so the dependency points down).
+MCU_TO_EBOOT_BOARD = {
+        # ARM Cortex-M/A (modern)
+        "stm32f4": "stm32f4",
+        "stm32h7": "stm32h7",
+        "stm32h743": "stm32h7",
+        "stm32mp1": "stm32mp1",
+        "nrf52": "nrf52",
+        "nrf52840": "nrf52",
+        "rpi4": "rpi4",
+        "rpi": "rpi4",
+        "raspberrypi": "rpi4",
+        "bcm2711": "rpi4",
+        "riscv64_virt": "riscv64_virt",
+        "esp32": "esp32",
+        "x86_64_efi": "x86_64_efi",
+        "imx8m": "imx8m",
+        "am64x": "am64x",
+        "am6442": "am64x",
+        "samd51": "samd51",
+        "sifive_u": "sifive_u",
+        "fu740": "sifive_u",
+        "qemu_arm64": "qemu_arm64",
+        "qemuarm64": "qemu_arm64",
+        "tms570": "cortex_r5",
+        "rm57": "cortex_r5",
+        "rm46": "cortex_r5",
+        # Intel StrongARM
+        "sa110": "strongarm",
+        "sa1100": "strongarm",
+        "sa1110": "strongarm",
+        # Intel XScale
+        "pxa250": "xscale",
+        "pxa255": "xscale",
+        "pxa270": "xscale",
+        "ixp420": "xscale",
+        "ixp425": "xscale",
+        "ixp465": "xscale",
+        # Fujitsu FR-V
+        "fr400": "frv",
+        "fr450": "frv",
+        "fr500": "frv",
+        "fr550": "frv",
+        "mb93091": "frv",
+        "mb93493": "frv",
+        # Hitachi/Renesas SuperH
+        "sh7604": "sh4",
+        "sh7091": "sh4",
+        "sh7750": "sh4",
+        "sh7751": "sh4",
+        "sh7709": "sh4",
+        "sh7710": "sh4",
+        "sh7203": "sh4",
+        "sh7206": "sh4",
+        # Hitachi/Renesas H8/300H
+        "h8300h": "h8300",
+        "h8s2148": "h8300",
+        "h8s2368": "h8300",
+        "h83048": "h8300",
+        "h83069": "h8300",
+        # Intel x86
+        "i386": "x86",
+        "i486": "x86",
+        "pentium": "x86",
+        "atom": "x86",
+        "quark": "x86",
+        # MIPS
+        "mips32": "mips",
+        "mips64": "mips",
+        "mips24k": "mips",
+        "mips34k": "mips",
+        "pic32": "mips",
+        "jz4740": "mips",
+        "ar9331": "mips",
+        # Matsushita/Panasonic AM3x
+        "mn1030": "mn103",
+        "mn103s": "mn103",
+        "am33": "mn103",
+        "am34": "mn103",
+        # Motorola/NXP PowerPC
+        "mpc8xx": "powerpc",
+        "mpc5200": "powerpc",
+        "mpc5554": "powerpc",
+        "mpc8260": "powerpc",
+        "mpc8540": "powerpc",
+        "p1020": "powerpc",
+        "p2020": "powerpc",
+        "t1040": "powerpc",
+        "ppc440": "powerpc",
+        "ppc405": "powerpc",
+        # Motorola 68k / ColdFire
+        "mc68000": "m68k",
+        "mc68020": "m68k",
+        "mc68030": "m68k",
+        "mc68040": "m68k",
+        "mc68060": "m68k",
+        "mcf5206": "m68k",
+        "mcf5272": "m68k",
+        "mcf5307": "m68k",
+        "mcf5407": "m68k",
+        "mcf5475": "m68k",
+        "mcf5282": "m68k",
+        "mcf52235": "m68k",
+        "mcf54418": "m68k",
+        # NEC/Renesas V850
+        "v850": "v850",
+        "v850e": "v850",
+        "v850e2": "v850",
+        "v850es": "v850",
+        "upd70f3002": "v850",
+        "rh850": "v850",
+        # Sun/Oracle SPARC
+        "sparc": "sparc",
+        "leon3": "sparc",
+        "leon4": "sparc",
+        "ut699": "sparc",
+        "gr712rc": "sparc",
+        "erc32": "sparc",
+        # --- TI ---
+        "msp430": "msp430",
+        "tms320f28": "c28x",
+        "tms320c67": "c6000",
+        "am335x_pru": "pru",
+        # --- Renesas + Infineon ---
+        "rl78": "rl78",
+        "rx65": "rx",
+        "rx72": "rx",
+        "tc397": "tricore",
+        "tc375": "tricore",
+        "xc2267": "c166",
+        # --- FPGA ---
+        "microblaze": "microblaze",
+        "nios2": "nios2",
+        "mor1kx": "openrisc",
+        "lm32": "lm32",
+        # --- DSP ---
+        "adsp_bf": "blackfin",
+        "adsp_21": "sharc",
+        "sdm845": "hexagon",
+        "ceva_xm": "ceva",
+        "hifi5": "xtensa_hifi",
+        # --- Misc ---
+        "arc_em": "arc",
+        "stc89": "8051",
+        "efm8": "8051",
+        "esp32c3": "esp32c3",
+        "esp32s3": "esp32s3",
+        # --- Server/exotic ---
+        "ultrasparc_t": "sparc64",
+        "power9": "ppc64",
+        "loongson": "loongarch",
+        "pa87": "parisc",
+        "itanium": "ia64",
+        "alpha21": "alpha",
+        "ibm_z": "s390",
+        "etrax": "cris",
+        "csr8675": "kalimba",
+}
+
+
+# Longest prefix first, computed once: shorter family rows (esp32)
+# must not shadow their more specific parts (esp32c3), and no caller
+# should re-sort the table per lookup.
+_MCU_PREFIXES = sorted(MCU_TO_EBOOT_BOARD.items(), key=lambda kv: -len(kv[0]))
+
+
+def board_dir_for_mcu(mcu):
+    """Longest-prefix MCU -> eBoot board directory lookup (None on a miss).
+
+    Public name (no leading underscore): shared across the module boundary by
+    ``eos_project_generator``, so a rename must update that caller too.
+    """
+    mcu = (mcu or "").lower()
+    for prefix, board in _MCU_PREFIXES:
+        if mcu.startswith(prefix):
+            return board
+    return None
+
+
+# Core-class board directories eBoot ships (generic ports shared by every
+# chip of that core: cortex_m3, arm9, cortex_a76, ...). Frozen list read from
+# the pinned eBoot revision in core/UPSTREAM.yaml at the time of writing —
+# the generated SDK's ``EBOOT_BOARD_DIR`` is resolved against the eBoot tree
+# the generated project pairs with (an eBoot clone), not against ebuild's
+# vendored test snapshot, which carries only the 26 legacy boards.
+_EBOOT_CORE_BOARDS = frozenset([
+    "8051", "alpha", "arc", "arm11", "arm7tdmi", "arm9", "avr", "avr32",
+    "blackfin", "c166", "c28x", "c6000", "ceva", "cortex_a15", "cortex_a35",
+    "cortex_a5", "cortex_a55", "cortex_a76", "cortex_a9", "cortex_m0",
+    "cortex_m0plus", "cortex_m23", "cortex_m3", "cortex_m33", "cortex_m55",
+    "cortex_m85", "cortex_r4", "cortex_r5", "cortex_r52", "cris", "dspic",
+    "esp32c3", "esp32s3", "hexagon", "kalimba", "mips64", "msp430",
+    "nrf52", "openrisc", "parisc", "pic16", "pic18", "pic24", "pic32",
+    "ppc64", "pru", "riscv32", "rl78", "rx", "s390", "sharc", "sparc64",
+    "stm32mp1", "strongarm", "tricore", "v850", "xscale", "xtensa_hifi",
+])
+
+
+def _normalise_core(core):
+    """Canonical core spelling for board-dir matching: lowercase, no
+    separators. ``Cortex-A9`` / ``cortex_a9`` / ``cortexa9`` all become
+    ``cortexa9``, so the analyzer's hyphen spellings and the on-disk
+    underscore spellings compare equal."""
+    return re.sub(r"[^a-z0-9]", "", (core or "").lower())
+
+
+# Core-name normalisation hits for the microarch suffixes the analyzer uses:
+# arm926ej-s is an ARM9, arm1176jzf-s is an ARM11, cortex-r4f is a Cortex-R4.
+_CORE_ABBREV = (
+    ("arm926ej", "arm9"),
+    ("arm1176jzf", "arm11"),
+    ("cortexr4f", "cortexr4"),
+    ("cortexm0", "cortexm0"),   # keep m0 distinct from m0plus below
+    ("cortexr5f", "cortexr5"),
+)
+
+
+def board_dir_for_core(core):
+    """Core-class board lookup against the boards eBoot actually ships
+    (None on a miss). Separator-insensitive: ``cortex-m3`` matches the
+    upstream ``cortex_m3``; ``arm926ej-s`` matches ``arm9``."""
+    norm = _normalise_core(core)
+    if not norm:
+        return None
+    # Exact normalised match first (cortex-m3 == cortex_m3), then a unique
+    # normalised prefix (arm926ej-s -> arm9); ambiguous prefixes miss.
+    for abbrev, target in _CORE_ABBREV:
+        if norm.startswith(abbrev) and abbrev != target:
+            norm = target
+            break
+    for d in _EBOOT_CORE_BOARDS:
+        if _normalise_core(d) == norm:
+            return d
+    return None
 
 TARGET_ARCH = {
     'stm32f4': {
@@ -144,12 +381,115 @@ EBOOT_BOARD = {
 }
 
 
-def get_eboot_board(target):
-    return EBOOT_BOARD.get(target, "x86")
+
+def _resolve_eboot_board_dir(target, profile=None):
+    """Resolve the eBoot board *directory* for a target.
+
+    Three-stage lookup, in order:
+      1. Exact target-name match in EBOOT_BOARD (the TARGET_ARCH target names
+         eBoot ships a board for, e.g. ``nrf52``, ``stm32f4``, ``raspi4``).
+      2. MCU-prefix match against MCU_TO_EBOOT_BOARD for a detected chip whose
+         board directory name the analyzer knows but the target table does not
+         (e.g. profile mcu ``nrf52840`` -> ``nrf52``).
+      3. Core-name match against the board list eBoot actually ships: eBoot
+         ports generic *core-class* boards (``cortex_m3``, ``arm9``, ...), so a
+         chip with no chip-named row still gets the real board its core uses
+         (``stm32f103`` -> ``cortex_m3``). Normalised: ``cortex-a9``/``cortexa9``
+         -> ``cortex_a9``, and separator spellings generally are matched by
+         stripping separators before comparing.
+
+    Returns the board directory name, or None when no stage matches. The
+    caller then fails closed (FATAL_ERROR) rather than inventing a board.
+    Stage 3 is last so no currently-resolving target changes.
+    """
+    if target in EBOOT_BOARD:
+        return EBOOT_BOARD[target]
+    if profile is not None:
+        board = board_dir_for_mcu(getattr(profile, "mcu", None))
+        if board is not None:
+            return board
+        return board_dir_for_core(getattr(profile, "core", None))
+    return None
+
+
+def _info_from_profile(profile):
+    """Derive a TARGET_ARCH-shaped info dict from a detected profile.
+
+    The architecture is tested before the core, so 64-bit ARM (``arch`` =
+    ``aarch64``/``arm64``) always wins over a Cortex-A core string, while
+    32-bit Cortex-A / ARM11 parts (Linux-class, ``arch`` = ``arm``) still get
+    ``arm-linux-gnueabihf`` and ``class: sbc`` rather than the bare-metal
+    ``arm-none-eabi``. Only architectures the SDK ships a toolchain for (ARM
+    Cortex-M/R, classic ARM7/ARM9/StrongARM/XScale, Cortex-A, AArch64, RISC-V)
+    return a dict; everything else returns None so the caller keeps the
+    original x86_64 fallback instead of
+    inventing a toolchain we do not have. The RISC-V width guard covers both
+    the exact ``riscv32`` arch and alternate spellings (``riscv32imac``) plus
+    core-only rows (``rv32imac``), so a 32-bit part can never fall through to a
+    64-bit toolchain.
+    """
+    arch = (getattr(profile, "arch", None) or "").lower()
+    core = (getattr(profile, "core", None) or "").lower()
+    vendor = getattr(profile, "vendor", "") or "Generic"
+    if "cortex-m" in core or "cortex-r" in core:
+        return {"arch": "arm", "triplet": "arm-none-eabi",
+                "cpu": core or "cortex-m4", "vendor": vendor,
+                "soc": getattr(profile, "mcu_family", "") or "MCU", "class": "mcu"}
+    if arch in ("aarch64", "arm64"):
+        return {"arch": "aarch64", "triplet": "aarch64-linux-gnu",
+                "cpu": core or "cortex-a53", "vendor": vendor,
+                "soc": getattr(profile, "mcu_family", "") or "SBC", "class": "sbc"}
+    if "cortex-a" in core or "arm11" in core:
+        return {"arch": "arm", "triplet": "arm-linux-gnueabihf",
+                "cpu": core or "cortex-a53", "vendor": vendor,
+                "soc": getattr(profile, "mcu_family", "") or "SBC", "class": "sbc"}
+    if arch == "arm":
+        # Classic ARM (ARM7TDMI / ARM9 / StrongARM / XScale): no Cortex core
+        # string. Class rule: ``class`` describes the EoS payload tier, not the
+        # bootloader — eBoot itself always builds bare-metal, so the loader
+        # never links against a *-linux-gnueabihf sysroot regardless of class.
+        # These parts have no MMU-capable Linux story in the shipped boards
+        # (their eBoot ports are direct-boot), so they land on arm-none-eabi +
+        # class: mcu, while Cortex-A application cores keep the hosted triplet
+        # + class: sbc (Linux payload) their boards are built for.
+        return {"arch": "arm", "triplet": "arm-none-eabi",
+                "cpu": core or "arm7tdmi", "vendor": vendor,
+                "soc": getattr(profile, "mcu_family", "") or "MCU", "class": "mcu"}
+    # riscv32 has no toolchain in the repo (only riscv64-* ship), so treat it
+    # like xtensa/MIPS: return None and let the caller keep the honest x86_64
+    # fallback rather than inventing a 64-bit toolchain for 32-bit silicon.
+    # Guards both the exact "riscv32" arch and alternate spellings ("riscv32imac")
+    # plus core-only rows ("rv32imac").
+    if arch.startswith("riscv32") or "rv32" in core:
+        return None
+    if "riscv" in arch:
+        return {"arch": "riscv64", "triplet": "riscv64-linux-gnu",
+                "cpu": core or "rv64gc", "vendor": vendor,
+                "soc": getattr(profile, "mcu_family", "") or "RISC-V", "class": "sbc"}
+    return None
 
 
 def generate_sdk(target, output_dir, hardware_file=None):
     info = get_target_info(target)
+    sdk_dir, _, _ = _write_sdk_files(target, info, output_dir,
+                                     toolchain_ok=target in TARGET_ARCH)
+    return sdk_dir
+
+
+def _write_sdk_files(target, info, output_dir, profile=None, toolchain_ok=True):
+    """Shared SDK file writer used by both name- and profile-based generation.
+
+    ``target`` is the board/MCU string and names the SDK directory
+    (``eos-sdk-<target>``); ``info`` drives the arch, toolchain triplet, eboot
+    board, and linker script. The two are independent so a detected chip such
+    as ``nrf52840`` keeps its directory name while inheriting the ``nrf52``
+    toolchain definition. ``profile`` (optional) lets a detected MCU whose
+    board eBoot ships resolve its eboot board via MCU prefix even when the
+    target name is not an EBOOT_BOARD key. ``toolchain_ok`` (default True) must
+    be False when ``info`` is a fallback rather than a real toolchain: a
+    resolved board directory is then dropped so the output can never pair a
+    real board with a fallback arch and look valid.
+    """
     sdk_dir = os.path.join(output_dir, "eos-sdk-" + target)
     for d in ["sysroot/usr/include", "sysroot/usr/lib", "sysroot/usr/lib/pkgconfig"]:
         os.makedirs(os.path.join(sdk_dir, d), exist_ok=True)
@@ -184,6 +524,12 @@ def generate_sdk(target, output_dir, hardware_file=None):
     env.append('export PKG_CONFIG_PATH="$EOS_SDK_SYSROOT/usr/lib/pkgconfig"')
     msg = f'echo "EoS SDK for {target} ({info["vendor"]} {info["soc"]}) initialized"'
     env.append(msg)
+    if not toolchain_ok:
+        # Fail-loud on the primary consumer surface: environment-setup exports
+        # CMAKE_TOOLCHAIN_FILE, which never includes eboot_board.cmake — without
+        # this echo a sourced env would silently hand out a desktop compiler.
+        env.append('echo "WARNING: unsupported target ' + target + ' - no toolchain '
+                   'ships for this chip; see eboot/eboot_board.cmake (ebuild sdk --list)"')
     with open(os.path.join(sdk_dir, "environment-setup"), "w") as f:
         f.write("\n".join(env) + "\n")
     if os.name != "nt":
@@ -201,6 +547,9 @@ def generate_sdk(target, output_dir, hardware_file=None):
     bat.append('set "CMAKE_TOOLCHAIN_FILE=%EOS_SDK_ROOT%\\toolchain.cmake"')
     bat.append('set "PKG_CONFIG_PATH=%EOS_SDK_SYSROOT%\\usr\\lib\\pkgconfig"')
     bat.append(f'echo EoS SDK for {target} ({info["vendor"]} {info["soc"]}) initialized')
+    if not toolchain_ok:
+        bat.append('echo WARNING: unsupported target ' + target + ' - no toolchain '
+                   'ships for this chip (ebuild sdk --list)')
     with open(os.path.join(sdk_dir, "environment-setup.bat"), "w") as f:
         f.write("\r\n".join(bat) + "\r\n")
     # sdk-info.txt
@@ -213,20 +562,25 @@ def generate_sdk(target, output_dir, hardware_file=None):
     si.append("Vendor:  " + info["vendor"])
     si.append("SoC:     " + info["soc"])
     si.append("Class:   " + info["class"])
+    if not toolchain_ok:
+        si.append("Toolchain:  fallback (unsupported target " + target + ")")
     with open(os.path.join(sdk_dir, "sdk-info.txt"), "w") as f:
         f.write("\n".join(si) + "\n")
     # manifest.json
+    target_entry = {
+        "name": target,
+        "arch": arch,
+        "cpu": info["cpu"],
+        "triplet": triplet,
+        "vendor": info["vendor"],
+        "soc": info["soc"],
+        "class": info["class"],
+    }
+    if not toolchain_ok:
+        target_entry["toolchain"] = "fallback"
     manifest = {
         "product": "eos-" + target,
-        "target": {
-            "name": target,
-            "arch": arch,
-            "cpu": info["cpu"],
-            "triplet": triplet,
-            "vendor": info["vendor"],
-            "soc": info["soc"],
-            "class": info["class"],
-        },
+        "target": target_entry,
         "network": {
             "default_ip": "192.168.1.100",
             "ebot_port": 8420,
@@ -234,8 +588,19 @@ def generate_sdk(target, output_dir, hardware_file=None):
     }
     with open(os.path.join(output_dir, "manifest.json"), "w") as f:
         json.dump(manifest, f, indent=2)
-    # Generate eboot board config for this target
-    eboot_board = get_eboot_board(target)
+    # Generate eboot board config for this target. Derive the board via the
+    # unified resolver (exact target-name match, then MCU-prefix match against
+    # the Tier-1 table). A detected chip the board table knows by MCU prefix
+    # (e.g. nrf52840 -> nrf52) gets its real board directory; the per-chip
+    # MEMORY block below is still gated on an exact target match. A toolchain
+    # miss drops the board entirely so the FATAL_ERROR block fires.
+    eboot_board = _resolve_eboot_board_dir(target, profile)
+    if not toolchain_ok:
+        # Fail closed on a toolchain miss: a resolved board directory must
+        # never be paired with a fallback (x86_64) arch — the two halves would
+        # contradict each other and the file would look valid. Drop the board
+        # so the FATAL_ERROR block below fires.
+        eboot_board = None
     eboot_dir = os.path.join(sdk_dir, "eboot")
     os.makedirs(eboot_dir, exist_ok=True)
 
@@ -246,7 +611,8 @@ def generate_sdk(target, output_dir, hardware_file=None):
     eboot_cfg.append("#define EBOOT_TARGET_CONFIG_H")
     eboot_cfg.append("")
     eboot_cfg.append('#define EBOOT_TARGET_NAME     "' + target + '"')
-    eboot_cfg.append('#define EBOOT_BOARD_NAME      "' + eboot_board + '"')
+    if eboot_board is not None:
+        eboot_cfg.append('#define EBOOT_BOARD_NAME      "' + eboot_board + '"')
     eboot_cfg.append('#define EBOOT_TARGET_ARCH     "' + arch + '"')
     eboot_cfg.append('#define EBOOT_TARGET_CPU      "' + info["cpu"] + '"')
     eboot_cfg.append('#define EBOOT_TARGET_VENDOR   "' + info["vendor"] + '"')
@@ -268,34 +634,41 @@ def generate_sdk(target, output_dir, hardware_file=None):
     eboot_cmake = []
     eboot_cmake.append("# Auto-generated eBoot board selection for " + target)
     eboot_cmake.append("set(EBOOT_TARGET " + target + ")")
-    eboot_cmake.append("set(EBOOT_BOARD " + eboot_board + ")")
+    if eboot_board is not None:
+        eboot_cmake.append("set(EBOOT_BOARD " + eboot_board + ")")
     eboot_cmake.append("set(EBOOT_ARCH " + arch + ")")
     eboot_cmake.append("set(EBOOT_CPU " + info["cpu"] + ")")
     if info["class"] == "mcu":
         eboot_cmake.append("set(EBOOT_BARE_METAL ON)")
     else:
         eboot_cmake.append("set(EBOOT_BARE_METAL OFF)")
-    line = 'set(EBOOT_BOARD_DIR "${CMAKE_CURRENT_LIST_DIR}/../eboot/boards/'
-    eboot_cmake.append(line + eboot_board + '")')
+    if eboot_board is not None:
+        line = 'set(EBOOT_BOARD_DIR "${CMAKE_CURRENT_LIST_DIR}/../eboot/boards/'
+        eboot_cmake.append(line + eboot_board + '")')
     with open(os.path.join(eboot_dir, "eboot_board.cmake"), "w") as f:
         f.write("\n".join(eboot_cmake) + "\n")
 
-    # eboot linker script selection (for MCUs)
-    if info["class"] == "mcu":
+    # eboot linker script selection (for MCUs). Only emit a per-chip linker
+    # script on an EXACT target match: the MEMORY figures below are per-part,
+    # not per-family, so a family board dir (e.g. stm32f401 -> stm32f4) must
+    # never select a sibling's memory map. Otherwise the linker would place
+    # .text past physical flash and _estack above physical SRAM.
+    linker_key = target if target in TARGET_ARCH else None
+    if info["class"] == "mcu" and linker_key is not None:
         ld = []
         ld.append("/* Auto-generated linker script for " + target + " */")
         ld.append("MEMORY {")
-        if target == "stm32f4":
+        if linker_key == "stm32f4":
             ld.append("  FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = 1024K")
             ld.append("  SRAM  (rwx) : ORIGIN = 0x20000000, LENGTH = 128K")
-        elif target == "stm32h7":
+        elif linker_key == "stm32h7":
             ld.append("  FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = 2048K")
             ld.append("  DTCM  (rwx) : ORIGIN = 0x20000000, LENGTH = 128K")
             ld.append("  SRAM  (rwx) : ORIGIN = 0x24000000, LENGTH = 512K")
-        elif target == "nrf52":
+        elif linker_key == "nrf52":
             ld.append("  FLASH (rx)  : ORIGIN = 0x00000000, LENGTH = 1024K")
             ld.append("  SRAM  (rwx) : ORIGIN = 0x20000000, LENGTH = 256K")
-        elif target == "rp2040":
+        elif linker_key == "rp2040":
             ld.append("  FLASH (rx)  : ORIGIN = 0x10000000, LENGTH = 2048K")
             ld.append("  SRAM  (rwx) : ORIGIN = 0x20000000, LENGTH = 264K")
         else:
@@ -313,15 +686,84 @@ def generate_sdk(target, output_dir, hardware_file=None):
         ld.append("}")
         with open(os.path.join(eboot_dir, "eboot_" + target + ".ld"), "w") as f:
             f.write("\n".join(ld) + "\n")
+    if eboot_board is None:
+        # Fail closed (Master Design §9.2): instead of writing nothing — which
+        # CMake would silently expand to an empty/wrong EBOOT_BOARD_DIR — append
+        # a FATAL_ERROR so any consumer that includes this file errors by name.
+        # Covers both a board miss and a toolchain miss (whose board was dropped
+        # above): an unsupported target gets an actionable diagnostic, never a
+        # half-valid file. The two diagnostics say which half missed: a
+        # toolchain miss fell back to the host compiler (name it), a board miss
+        # has a good toolchain but no board for this chip (name the chip, not
+        # `ebuild sdk --list`, which lists TARGET_ARCH targets and can never
+        # contain a detected MCU like stm32f103).
+        with open(os.path.join(eboot_dir, "eboot_board.cmake"), "a") as f:
+            if not toolchain_ok:
+                f.write('message(FATAL_ERROR "eos-sdk-' + target + ': no cross-toolchain '
+                        'ships for ' + target + '; the SDK fell back to the host '
+                        'x86_64 compiler. Run `ebuild sdk --list` for supported targets.")\n')
+            else:
+                f.write('message(FATAL_ERROR "eos-sdk-' + target + ': eBoot ships no '
+                        'board port for ' + target + ' (toolchain ' + triplet + ' is '
+                        'correct). Check eBoot boards/ for a port covering this chip.")\n')
+        if not toolchain_ok:
+            print("  [warn] no cross-toolchain ships for " + target + ": fell back to the "
+                  "host x86_64 compiler; FATAL_ERROR written, no linker script. "
+                  "Run `ebuild sdk --list`.")
+        else:
+            print("  [warn] eBoot ships no board port for " + target + " (toolchain " +
+                  triplet + " is correct): FATAL_ERROR written, no linker script. "
+                  "Check eBoot boards/ for a port covering this chip.")
+    elif info["class"] == "mcu" and linker_key is None:
+        # Board resolved (family-wide directory) but no memory map exists for
+        # this exact part: say so explicitly instead of going silent.
+        print("  [warn] no per-chip linker script for " + target +
+              ": eBoot ships no memory map for this exact part. "
+              "Run `ebuild sdk --list` for supported targets.")
 
-    print("  eBoot board: " + eboot_board + " (" + info["class"] + ")")
+    print("  eBoot board: " + (eboot_board if eboot_board is not None else "none (unmapped)") + " (" + info["class"] + ")")
 
     print("EoS SDK generated for " + target)
     print("  Vendor:  " + info["vendor"] + " " + info["soc"])
     print("  Arch:    " + arch + " (" + info["cpu"] + ")")
     print("  Triplet: " + triplet)
     print("  Location: " + sdk_dir)
-    return sdk_dir
+    return sdk_dir, toolchain_ok, eboot_board
+
+
+def generate_sdk_from_profile(profile, output_dir, target=None):
+    """Generate an EoS SDK from a detected ``HardwareProfile``.
+
+    The directory/target name is taken from the caller (the board string the
+    pipeline resolved), not from ``profile.mcu``: several documented targets
+    (``raspi4``, ``vexpress``, ``riscv_virt``, ``malta``, ``qemu_virt``,
+    ``raspi3``) have no ``mcu`` in the analyzer, so deriving the name from it
+    produced an empty ``eos-sdk-`` directory. Priority:
+
+    1. If the resolved target is a known ``TARGET_ARCH`` key, use that
+       canonical mapping exactly as the legacy ``generate_sdk`` would. This
+       keeps every supported board byte-identical to the pre-fix behavior,
+       including its eboot board.
+    2. Otherwise derive the toolchain from the detected profile (core, arch,
+       vendor, ``EOS_ENABLE_*`` flags) so a chip the analyzer identified but
+       the name table does not know (e.g. ``nrf52840``) gets the right
+       toolchain instead of the silent x86_64 fallback. Chips the SDK has no
+       toolchain for keep the honest x86_64 fallback.
+
+    Returns ``(sdk_dir, toolchain_ok, eboot_board)`` so callers can fail the
+    pipeline on an unsupported target instead of logging success.
+    """
+    target = (target or getattr(profile, "mcu", "") or "").lower() or "unknown"
+    if target in TARGET_ARCH:
+        info = get_target_info(target)
+        toolchain_ok = True
+    else:
+        info = _info_from_profile(profile)
+        toolchain_ok = info is not None
+        if info is None:
+            info = get_target_info(target)
+    return _write_sdk_files(target, info, output_dir, profile=profile,
+                            toolchain_ok=toolchain_ok)
 
 
 def list_targets():

--- a/tests/ebuild/README.md
+++ b/tests/ebuild/README.md
@@ -90,7 +90,7 @@ Requires `../eos` and `../eboot` checked out alongside `ebuild`.
 | `TestEbuildMCUDatabase` | 7 | `MCU_DATABASE` entries: tms570/tms570lc/rm57 (`cortex-r5f`), rm46/rz_t1 (`cortex-r4f`), text detection roundtrip |
 | `TestEbuildCLIBoardMap` | 6 | `commands.py` `board_map`: tms570 with `arm`/`cortex-r5f`/`arm-none-eabi`/`ti`, am64x hybrid |
 | `TestEbuildPredefinedToolchains` | 3 | `toolchain.py` `PREDEFINED_TOOLCHAINS`: `arm-none-eabi` entry with correct prefix and arch |
-| `TestEbuildProjectGenerator` | 4 | `eos_project_generator.py`: `MCU_TO_EBOOT_BOARD` (tms570/rm57/rm46 → `cortex_r5`), `ARCH_TO_TOOLCHAIN` (`arm-cortex-r` → `arm-none-eabi-r5.yaml`) |
+| `TestEbuildProjectGenerator` | 4 | `ebuild/sdk_generator.py`: `MCU_TO_EBOOT_BOARD` (tms570/rm57/rm46 → `cortex_r5`), `ARCH_TO_TOOLCHAIN` (`arm-cortex-r` → `arm-none-eabi-r5.yaml`) |
 
 #### End-to-End (10 tests)
 

--- a/tests/unit/test_sdk_from_profile.py
+++ b/tests/unit/test_sdk_from_profile.py
@@ -1,0 +1,708 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 EoS Project
+"""Regression + feature tests for profile-driven SDK generation.
+
+Method (characterization-first, per Working Effectively with Legacy Code):
+1. test_sdk_from_name_falls_back_to_x86_64 pins the legacy name-based fallback
+   of generate_sdk(name) for an unknown MCU -- it must still regress to x86_64
+   so we never silently "fix" the fallback and break callers that rely on it.
+2. test_sdk_from_profile_nrf52840 proves the P0 fix: a detected nrf52840
+   profile now yields an arm-none-eabi SDK with the right EOS_ENABLE_* header,
+   not a host x86_64 toolchain.
+3. test_pipeline_sdk_raspi4_stays_aarch64 proves a documented TARGET_ARCH
+   target the analyzer gives no `mcu` for keeps its canonical aarch64 toolchain
+   (the exact defect the PR fixes, must not be reintroduced).
+4. test_detected_unmapped_mcu_skips_foreign_linker_script proves a detected MCU
+   not in EBOOT_BOARD gets the honest x86_64 fallback and NO wrong memory map.
+"""
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from ebuild.sdk_generator import (
+    EBOOT_BOARD,
+    TARGET_ARCH,
+    _info_from_profile,
+    _resolve_eboot_board_dir,
+    board_dir_for_core,
+    board_dir_for_mcu,
+    generate_sdk,
+    generate_sdk_from_profile,
+)
+from ebuild.eos_ai.eos_hw_analyzer import HardwareProfile, PeripheralInfo
+
+
+def _read(path):
+    with open(path) as f:
+        return f.read()
+
+
+def _proc_eboot(sdk_dir):
+    import re
+
+    tc = _read(os.path.join(sdk_dir, "toolchain.cmake"))
+    proc = re.search(r"CMAKE_SYSTEM_PROCESSOR ([a-z0-9_]+)", tc)
+    proc = proc.group(1) if proc else "?"
+    eb = _read(os.path.join(sdk_dir, "eboot", "eboot_board.cmake"))
+    board = re.search(r"set\(EBOOT_BOARD ([^)]+)\)", eb)
+    board = board.group(1).strip() if board else "?"
+    return proc, board
+
+
+def test_sdk_from_name_falls_back_to_x86_64():
+    """Pin the legacy name-based fallback: unknown MCU -> x86_64 SDK.
+
+    This is the behaviour the P0 fix deliberately preserves for callers that
+    only have a target string. If it ever changes, the fallback regressed.
+    """
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir = generate_sdk("nrf52840", out)
+        tc = _read(os.path.join(sdk_dir, "toolchain.cmake"))
+        # Legacy table has no nrf52840 -> default x86_64 triplet.
+        assert "x86_64-linux-gnu-gcc" in tc, tc
+        info = _read(os.path.join(sdk_dir, "sdk-info.txt"))
+        assert "Arch:    x86_64" in info, info
+
+
+def test_sdk_from_profile_nrf52840():
+    """P0 fix: detected nrf52840 profile -> arm-none-eabi SDK, not x86_64.
+
+    Drive the SDK from the detected profile. nrf52840 is in the analyzer DB so
+    it resolves to an arm-none-eabi toolchain, while the legacy name-only path
+    would have emitted x86_64.
+    """
+    profile = HardwareProfile()
+    profile.mcu = "nrf52840"
+    profile.arch = "arm"
+    profile.core = "cortex-m4f"
+    profile.vendor = "Nordic"
+    profile.mcu_family = "nRF52"
+    profile.peripherals = [
+        PeripheralInfo(name="ble", peripheral_type="ble"),
+        PeripheralInfo(name="i2c", peripheral_type="i2c"),
+        PeripheralInfo(name="spi", peripheral_type="spi"),
+    ]
+
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir, _, _ = generate_sdk_from_profile(profile, out, target="nrf52840")
+        tc = _read(os.path.join(sdk_dir, "toolchain.cmake"))
+        assert "arm-none-eabi-gcc" in tc, "SDK must target the detected ARM chip, got:\n" + tc
+        assert "x86_64" not in tc, "P0 regression: SDK regressed to host x86_64"
+        info = _read(os.path.join(sdk_dir, "sdk-info.txt"))
+        assert "Arch:    arm" in info, info
+        # Manifest records the detected target, not the host.
+        manifest = json.loads(_read(os.path.join(out, "manifest.json")))
+        assert manifest["target"]["arch"] == "arm", manifest
+        assert manifest["target"]["triplet"] == "arm-none-eabi", manifest
+
+
+def test_pipeline_sdk_matches_detected_profile():
+    """End-to-end guard: the pipeline SDK step must follow the detected profile.
+
+    _run_pipeline_steps detects nrf52840 in the analyzer DB, then Step 4 must
+    emit an arm-none-eabi SDK. If the pipeline ever reverts to
+    generate_sdk(board.lower()), this FAILS because the name-only path produces
+    an x86_64 SDK for nrf52840.
+    """
+    from ebuild.cli.commands import _run_pipeline_steps
+    from ebuild.cli.logger import Logger
+
+    with tempfile.TemporaryDirectory() as out:
+        build_dir = os.path.join(out, "_build")
+        profile, _configs, _boot = _run_pipeline_steps(
+            board="nrf52840", hardware=None, build_dir=Path(build_dir), log=Logger(verbose=False)
+        )
+        # Analyzer detected the ARM chip.
+        assert profile.arch == "arm", profile.arch
+        sdk_dir = os.path.join(build_dir, "sdk")
+        tc = _read(os.path.join(sdk_dir, "eos-sdk-nrf52840", "toolchain.cmake"))
+        assert "arm-none-eabi-gcc" in tc, "pipeline SDK must match detected ARM chip:\n" + tc
+        assert "x86_64" not in tc, "P0 regression: pipeline SDK regressed to host x86_64"
+
+
+def test_pipeline_sdk_raspi4_stays_aarch64():
+    """Documented target with no analyzer `mcu` keeps its canonical toolchain.
+
+    raspi4 is a TARGET_ARCH key but the analyzer gives it no `mcu`, so the
+    profile path must fall back to get_target_info("raspi4") and keep
+    aarch64-linux-gnu, never an empty `eos-sdk-` dir or an x86_64 SDK. This is
+    the exact defect the PR exists to fix; reintroducing it here fails.
+    """
+    from ebuild.cli.commands import _run_pipeline_steps
+    from ebuild.cli.logger import Logger
+
+    with tempfile.TemporaryDirectory() as out:
+        build_dir = os.path.join(out, "_build")
+        _run_pipeline_steps(
+            board="raspi4", hardware=None, build_dir=Path(build_dir), log=Logger(verbose=False)
+        )
+        sdk_dir = os.path.join(build_dir, "sdk", "eos-sdk-raspi4")
+        tc = _read(os.path.join(sdk_dir, "toolchain.cmake"))
+        assert "aarch64-linux-gnu-gcc" in tc, "raspi4 must stay aarch64, got:\n" + tc
+        assert "x86_64" not in tc, "raspi4 regressed to host x86_64"
+        # Directory name is correct, not empty.
+        assert os.path.isdir(sdk_dir), "eos-sdk-raspi4 directory must exist"
+
+
+def test_detected_unmapped_mcu_skips_foreign_linker_script():
+    """A detected Cortex-M part absent from EBOOT_BOARD gets the right detected
+    toolchain (arm-none-eabi) and NO linker script carrying another chip's
+    memory map.
+
+    stm32f103 is a Cortex-M part the analyzer detects, so it must compile with
+    arm-none-eabi (the whole point of the fix). eboot ships no board for it, so
+    the writer must skip the per-chip .ld rather than emit a foreign memory map
+    (the old code wrote an nRF52 linker script here).
+    """
+    profile = HardwareProfile()
+    profile.mcu = "stm32f103"
+    profile.arch = "arm"
+    profile.core = "cortex-m3"
+    profile.vendor = "ST"
+    profile.mcu_family = "STM32F1"
+
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir, _, _ = generate_sdk_from_profile(profile, out, target="stm32f103")
+        # Detected MCU -> correct bare-metal toolchain (not the host x86_64).
+        tc = _read(os.path.join(sdk_dir, "toolchain.cmake"))
+        assert "arm-none-eabi-gcc" in tc, tc
+        assert "x86_64" not in tc, "detected MCU must not fall back to host x86_64"
+        # No foreign per-chip linker script must be written.
+        ld = os.path.join(sdk_dir, "eboot", "eboot_stm32f103.ld")
+        assert not os.path.exists(ld), "must not emit another chip's memory map"
+
+
+def test_sdk_from_profile_unknown_mcu_uses_fallback():
+    """A profile with no usable arch/core still degrades to the x86_64 fallback."""
+    profile = HardwareProfile()
+    profile.mcu = "some-unknown-part"
+    profile.arch = ""
+    profile.core = ""
+    profile.vendor = ""
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir, _, _ = generate_sdk_from_profile(profile, out, target="some-unknown-part")
+        tc = _read(os.path.join(sdk_dir, "toolchain.cmake"))
+        assert "x86_64-linux-gnu-gcc" in tc, tc
+
+
+def test_known_targets_do_not_regress_through_pipeline():
+    """Every supported board keeps its legacy toolchain + eboot through the pipeline.
+
+    A known board (a TARGET_ARCH key) must produce exactly the same
+    CMAKE_SYSTEM_PROCESSOR and EBOOT_BOARD through the pipeline as the legacy
+    generate_sdk(name) call. generate_sdk_from_profile must prefer the canonical
+    name mapping for known targets and only enrich boards the name table lacks.
+    """
+    from ebuild.cli.commands import _run_pipeline_steps
+    from ebuild.cli.logger import Logger
+
+    for name in TARGET_ARCH:
+        with tempfile.TemporaryDirectory() as leg_out:
+            leg_dir = generate_sdk(name, leg_out)
+            leg_proc, leg_board = _proc_eboot(leg_dir)
+
+        with tempfile.TemporaryDirectory() as out:
+            build_dir = os.path.join(out, "_build")
+            _run_pipeline_steps(
+                board=name, hardware=None, build_dir=Path(build_dir), log=Logger(verbose=False)
+            )
+            pipe_proc, pipe_board = _proc_eboot(
+                os.path.join(build_dir, "sdk", "eos-sdk-" + name.lower())
+            )
+
+        assert pipe_proc == leg_proc, f"{name}: toolchain {pipe_proc} != legacy {leg_proc}"
+        assert pipe_board == leg_board, f"{name}: eboot {pipe_board} != legacy {leg_board}"
+
+
+def test_profile_aarch64_core_cortex_a72_is_64bit_toolchain():
+    """arch=arm64 + core=cortex-a72 must be aarch64-linux-gnu.
+
+    The 64-bit arch must win over the Cortex-A core string, so a 64-bit ARM
+    part (e.g. rk3588 = cortex-a76, or an unknown cortex-a72 part) gets the
+    64-bit toolchain, not the 32-bit arm-linux-gnueabihf the previous Core-
+    before-Arch ordering produced. This is a case where arch and core disagree
+    and the previous suite had no such example.
+    """
+    profile = HardwareProfile()
+    profile.mcu = "rk3588"
+    profile.arch = "arm64"
+    profile.core = "cortex-a72"
+    profile.vendor = "Rockchip"
+    profile.mcu_family = "RK3588"
+
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir, _, _ = generate_sdk_from_profile(profile, out, target="rk3588")
+        tc = _read(os.path.join(sdk_dir, "toolchain.cmake"))
+        assert "aarch64-linux-gnu-gcc" in tc, "64-bit ARM must get aarch64 toolchain, got:\n" + tc
+        assert "arm-linux-gnueabihf" not in tc, "regressed to 32-bit toolchain for 64-bit ARM"
+        assert "x86_64" not in tc, "regressed to host x86_64"
+        info = _read(os.path.join(sdk_dir, "sdk-info.txt"))
+        assert "Arch:    aarch64" in info, info
+
+
+def test_profile_riscv64_is_sbc_class():
+    """Detected riscv64 is class=sbc, not a virtual machine.
+
+    A real 64-bit RISC-V part (e.g. sifive_u = rv64gc) must get riscv64-linux-gnu
+    and class=sbc. The previous code labelled every detected RISC-V part as
+    class=virtual, discarding the real-silicon vs QEMU distinction that
+    TARGET_ARCH itself makes (riscv_virt=virtual, sifive_u=sbc).
+    """
+    profile = HardwareProfile()
+    profile.mcu = "sifive_u"
+    profile.arch = "riscv64"
+    profile.core = "rv64gc"
+    profile.vendor = "SiFive"
+    profile.mcu_family = "FU740"
+
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir, _, _ = generate_sdk_from_profile(profile, out, target="sifive_u")
+        tc = _read(os.path.join(sdk_dir, "toolchain.cmake"))
+        assert "riscv64-linux-gnu-gcc" in tc, "riscv64 must get riscv64 toolchain, got:\n" + tc
+        assert "x86_64" not in tc, "regressed to host x86_64"
+        info = _read(os.path.join(sdk_dir, "sdk-info.txt"))
+        assert "Arch:    riscv64" in info, info
+        assert "Class:   sbc" in info, "detected RISC-V must be class=sbc, not virtual:\n" + info
+
+
+def test_profile_riscv32_uses_honest_fallback():
+    """riscv32 has no repo toolchain, so it must NOT get a
+    64-bit triplet. Returning None makes the caller keep the honest x86_64
+    fallback instead of inventing riscv64-linux-gnu for 32-bit silicon
+    (esp32c3 / sifive_e / gd32vf103 in MCU_DATABASE are rv32imac)."""
+    profile = HardwareProfile()
+    profile.mcu = "esp32c3"
+    profile.arch = "riscv32"
+    profile.core = "rv32imc"
+    profile.vendor = "Espressif"
+    profile.mcu_family = "ESP32C3"
+
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir, _, _ = generate_sdk_from_profile(profile, out, target="esp32c3")
+        tc = _read(os.path.join(sdk_dir, "toolchain.cmake"))
+        assert "riscv64-linux-gnu-gcc" not in tc, "must not emit 64-bit toolchain for 32-bit RISC-V:\n" + tc
+        # Honest fallback: x86_64 (no rv32 toolchain ships in the repo).
+        assert "x86_64-linux-gnu-gcc" in tc, "riscv32 must fall back to x86_64, got:\n" + tc
+
+
+def test_unmapped_mcu_emits_no_x86_eboot_board():
+    """A detected MCU must never fall back to the x86 eboot board (the master
+    bug). stm32f103 now resolves the upstream cortex_m3 core-class board via
+    stage 3, so the honest-board assertion lives in
+    test_pipeline_completes_for_good_toolchain_missing_board; this test keeps
+    guarding the never-x86 rule with a part whose board eBoot genuinely does
+    not ship (atmega328p, AVR, no x86_64 default).
+    """
+    profile = HardwareProfile()
+    profile.mcu = "atmega328p"
+    profile.arch = "avr"
+    profile.core = "avr5"
+    profile.vendor = "Microchip"
+    profile.mcu_family = "AVR"
+
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir, _, _ = generate_sdk_from_profile(profile, out, target="atmega328p")
+        cfg = _read(os.path.join(sdk_dir, "eboot", "eboot_board.cmake"))
+        assert "EBOOT_BOARD x86" not in cfg, "must not silently pick x86 board:\n" + cfg
+        assert "EBOOT_BOARD " not in cfg, "no eboot board must be emitted for unmapped MCU:\n" + cfg
+        hdr = _read(os.path.join(sdk_dir, "eboot", "eboot_target_config.h"))
+        assert "EBOOT_BOARD_NAME" not in hdr, "no board name for unmapped MCU:\n" + hdr
+
+
+def test_eboot_key_is_target_name_or_none():
+    """_resolve_eboot_board_dir must return a board dir, or None on a miss.
+
+    Stage 1 (no profile): exact target-name match in EBOOT_BOARD, else None.
+    Stage 2 (with profile): MCU-prefix match against the analyzer's map, so a
+    detected chip whose board the target table knows only by MCU prefix (e.g.
+    nrf52840 -> nrf52) resolves, which the old target-only lookup never did.
+    """
+    from ebuild.sdk_generator import _resolve_eboot_board_dir
+
+    # Stage 1: target-name match
+    assert _resolve_eboot_board_dir("riscv_virt") == "riscv64_virt"
+    assert _resolve_eboot_board_dir("nrf52") == "nrf52"
+    assert _resolve_eboot_board_dir("not-a-real-chip") is None
+
+    # Stage 2: MCU-prefix match needs a profile
+    profile = HardwareProfile()
+    profile.mcu = "nrf52840"
+    assert _resolve_eboot_board_dir("nrf52840", profile) == "nrf52"
+    # Bare profile (no core set): stage 2 misses on the MCU name and stage 3
+    # has no core to match, so a chip-named miss stays a miss here. With a
+    # real core (cortex-m3) stm32f103 resolves via stage 3 — pinned in
+    # test_pipeline_completes_for_good_toolchain_missing_board.
+    profile.mcu = "stm32f103"
+    assert _resolve_eboot_board_dir("stm32f103", profile) is None
+
+    # Every TARGET_ARCH key that has an eboot board resolves to a real board
+    # directory (a value in EBOOT_BOARD), or None when eBoot ships no board.
+    valid = set(EBOOT_BOARD.values())
+    for key in TARGET_ARCH:
+        resolved = _resolve_eboot_board_dir(key)
+        assert resolved is None or resolved in valid, (key, resolved)
+
+
+def test_pipeline_nrf52840_gets_eboot_nrf52():
+    """Flagship example must end up with a real eBoot board.
+
+    nrf52840 is not a TARGET_ARCH key, but the analyzer knows it by MCU prefix
+    (MCU_TO_EBOOT_BOARD: nrf52840 -> nrf52). The profile path must resolve it
+    so the headline example produces a usable SDK, not a fail-loud no-board.
+    """
+    profile = HardwareProfile()
+    profile.mcu = "nrf52840"
+    profile.arch = "arm"
+    profile.core = "cortex-m4f"
+    profile.vendor = "Nordic"
+    profile.mcu_family = "nRF52"
+
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir, _, _ = generate_sdk_from_profile(profile, out, target="nrf52840")
+        eb = _read(os.path.join(sdk_dir, "eboot", "eboot_board.cmake"))
+        assert "set(EBOOT_BOARD nrf52)" in eb, eb
+        # nrf52840 is not an exact TARGET_ARCH key, so no per-chip MEMORY block
+        # is emitted (a family board dir must never select a memory map).
+        assert not os.path.exists(os.path.join(sdk_dir, "eboot", "eboot_nrf52840.ld"))
+        info = _read(os.path.join(sdk_dir, "sdk-info.txt"))
+        assert "Vendor:  Nordic" in info, info
+
+
+def test_stm32f103_still_no_eboot_and_fails_closed():
+    """stm32f103 has no chip-named MCU row: stage 3 resolves the upstream
+    cortex_m3 core-class board, so it no longer fails closed — it gets the
+    real board (see test_pipeline_completes_for_good_toolchain_missing_board).
+    This test now pins the chip-named-row miss behaviour on a part whose core
+    eBoot also does not ship: the FATAL_ERROR text names the chip honestly.
+    """
+    profile = HardwareProfile()
+    profile.mcu = "atmega328p"
+    profile.arch = "avr"
+    profile.core = "avr5"
+    profile.vendor = "Microchip"
+    profile.mcu_family = "AVR"
+
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir, _, _ = generate_sdk_from_profile(profile, out, target="atmega328p")
+        eb = _read(os.path.join(sdk_dir, "eboot", "eboot_board.cmake"))
+        assert "EBOOT_BOARD " not in eb
+        assert "FATAL_ERROR" in eb and "atmega328p" in eb, eb
+        # Toolchain also misses (no avr toolchain): the diagnostic says so.
+        assert "no cross-toolchain" in eb, eb
+
+
+def test_riscv_alt_spelling_falls_back():
+    """rv32* / riscv32imac must not slip through to riscv64 (finding 5)."""
+    p = HardwareProfile()
+    p.mcu = "custom32"
+    p.arch = "riscv32imac"
+    p.core = "rv32imac"
+    assert _info_from_profile(p) is None
+    p2 = HardwareProfile()
+    p2.mcu = "x"
+    p2.arch = "riscv"
+    p2.core = "rv32imac"
+    assert _info_from_profile(p2) is None
+
+
+def test_vendor_threaded_from_profile():
+    """Analyzer vendor is carried into the SDK, not dropped to Generic (F4)."""
+    p = HardwareProfile()
+    p.mcu = "nrf52840"
+    p.arch = "arm"
+    p.core = "cortex-m4f"
+    p.vendor = "Nordic"
+    p.mcu_family = "nRF52"
+    assert _info_from_profile(p)["vendor"] == "Nordic"
+
+
+def test_family_sibling_does_not_inherit_flagship_memory_map():
+    """stm32f401 prefix-matches the stm32f4 board but has 256K/64K, not 1024K/128K.
+
+    The MCU-prefix match may select the board *directory* (family-wide), but it
+    must never select the per-chip MEMORY block. A sibling gets board vars and
+    a warning, never a foreign linker script.
+    """
+    profile = HardwareProfile()
+    profile.mcu = "stm32f401"
+    profile.arch = "arm"
+    profile.core = "cortex-m4"
+    profile.vendor = "ST"
+    profile.mcu_family = "STM32F4"
+
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir, _, _ = generate_sdk_from_profile(profile, out, target="stm32f401")
+        assert not os.path.exists(os.path.join(sdk_dir, "eboot", "eboot_stm32f401.ld"))
+        eb = _read(os.path.join(sdk_dir, "eboot", "eboot_board.cmake"))
+        assert "set(EBOOT_BOARD stm32f4)" in eb, eb
+
+
+def test_toolchain_miss_fails_closed_despite_resolved_board():
+    """A resolved board paired with an unsupported toolchain must fail closed.
+
+    A detected Xtensa part prefix-matches an eBoot board dir, but the SDK ships
+    no Xtensa toolchain, so the output falls back to x86_64. Emitting the real
+    board next to a fallback arch looks valid but is contradictory — the writer
+    must emit no EBOOT_BOARD and a FATAL_ERROR instead.
+    """
+    profile = HardwareProfile()
+    profile.mcu = "esp32dev"
+    profile.arch = "xtensa"
+    profile.core = "lx6"
+    profile.vendor = "Espressif"
+    profile.mcu_family = "ESP32"
+
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir, _, _ = generate_sdk_from_profile(profile, out, target="esp32dev")
+        tc = _read(os.path.join(sdk_dir, "toolchain.cmake"))
+        assert "x86_64-linux-gnu-gcc" in tc, tc
+        eb = _read(os.path.join(sdk_dir, "eboot", "eboot_board.cmake"))
+        assert "set(EBOOT_BOARD " not in eb, eb
+        assert "FATAL_ERROR" in eb and "esp32dev" in eb, eb
+
+
+def test_toolchain_miss_is_marked_fallback_everywhere():
+    """A toolchain miss must be visible on every consumer surface, not just the
+    eboot cmake file: environment-setup exports CMAKE_TOOLCHAIN_FILE (which
+    never includes eboot_board.cmake), so a sourced env would silently hand out
+    a desktop compiler for an unmapped chip — the exact defect this PR fixes.
+    """
+    profile = HardwareProfile()
+    profile.mcu = "esp32dev"
+    profile.arch = "xtensa"
+    profile.core = "lx6"
+    profile.vendor = "Espressif"
+    profile.mcu_family = "ESP32"
+
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir, _, _ = generate_sdk_from_profile(profile, out, target="esp32dev")
+        manifest = json.loads(_read(os.path.join(out, "manifest.json")))
+        assert manifest["target"].get("toolchain") == "fallback", manifest
+        info = _read(os.path.join(sdk_dir, "sdk-info.txt"))
+        assert "Toolchain:  fallback" in info, info
+        env = _read(os.path.join(sdk_dir, "environment-setup"))
+        assert "unsupported target esp32dev" in env, env
+        bat = _read(os.path.join(sdk_dir, "environment-setup.bat"))
+        assert "unsupported target esp32dev" in bat, bat
+
+
+def test_supported_target_has_no_fallback_markers():
+    """Known targets stay byte-identical: no fallback keys appear anywhere."""
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir = generate_sdk("nrf52", out)
+        manifest = json.loads(_read(os.path.join(out, "manifest.json")))
+        assert "toolchain" not in manifest["target"], manifest
+        info = _read(os.path.join(sdk_dir, "sdk-info.txt"))
+        assert "fallback" not in info, info
+        env = _read(os.path.join(sdk_dir, "environment-setup"))
+        assert "unsupported target" not in env, env
+
+
+def test_generate_sdk_from_profile_returns_status_triple():
+    """Callers (pipeline step 4) need the resolution status, not just the dir."""
+    ok_profile = HardwareProfile()
+    ok_profile.mcu = "nrf52840"
+    ok_profile.arch = "arm"
+    ok_profile.core = "cortex-m4f"
+    ok_profile.vendor = "Nordic"
+    ok_profile.mcu_family = "nRF52"
+    miss_profile = HardwareProfile()
+    miss_profile.mcu = "esp32dev"
+    miss_profile.arch = "xtensa"
+    miss_profile.core = "lx6"
+
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir, toolchain_ok, eboot_board = generate_sdk_from_profile(
+            ok_profile, out, target="nrf52840")
+        assert os.path.isdir(sdk_dir)
+        assert toolchain_ok is True
+        assert eboot_board == "nrf52"
+        _, toolchain_ok, eboot_board = generate_sdk_from_profile(
+            miss_profile, out, target="esp32dev")
+        assert toolchain_ok is False
+        assert eboot_board is None
+
+
+def test_prefix_scan_prefers_longest_match():
+    """The MCU-prefix scan must prefer the longest prefix: esp32c3/esp32s3 both
+    start with esp32, and ultrasparc_t starts with ultrasparc — first-match
+    order would resolve all three to the wrong (shorter) board dir.
+    """
+    for mcu, board in (("esp32c3", "esp32c3"), ("esp32s3", "esp32s3"),
+                       ("ultrasparc_t", "sparc64")):
+        profile = HardwareProfile()
+        profile.mcu = mcu
+        assert _resolve_eboot_board_dir(mcu, profile) == board, mcu
+
+
+def test_pipeline_completes_for_good_toolchain_missing_board(capsys):
+    """A correct toolchain with no eBoot board must warn and continue, not exit.
+
+    stm32f103 derives arm-none-eabi correctly; eBoot ships no board for it.
+    The pipeline must finish (master completed for these chips) while the
+    board consumer still fails by name via the FATAL_ERROR in
+    eboot_board.cmake.
+    """
+    from ebuild.cli.commands import _run_pipeline_steps
+    from ebuild.cli.logger import Logger
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as out:
+        _run_pipeline_steps(board="stm32f103", hardware=None,
+                            build_dir=Path(out), log=Logger(verbose=False))
+        sdk_dir = os.path.join(out, "sdk", "eos-sdk-stm32f103")
+        tc = _read(os.path.join(sdk_dir, "toolchain.cmake"))
+        assert "arm-none-eabi-gcc" in tc, tc
+        eb = _read(os.path.join(sdk_dir, "eboot", "eboot_board.cmake"))
+        # eBoot ships a cortex_m3 board port upstream: the board must resolve,
+        # not fail closed (the FATAL_ERROR here would be a false statement).
+        assert "FATAL_ERROR" not in eb, eb
+        assert "set(EBOOT_BOARD cortex_m3)" in eb, eb
+    captured = capsys.readouterr()
+    assert "no eBoot board for stm32f103" not in captured.out + captured.err
+
+
+def test_legacy_name_path_marks_fallback_on_all_surfaces():
+    """Legacy generate_sdk with an unmapped name gets the FATAL_ERROR and all
+    four fallback markers — honest labelling, same as the profile path.
+    """
+    with tempfile.TemporaryDirectory() as out:
+        sdk_dir = generate_sdk("stm32f103", out)
+        eb = _read(os.path.join(sdk_dir, "eboot", "eboot_board.cmake"))
+        assert "FATAL_ERROR" in eb, eb
+        manifest = json.loads(_read(os.path.join(out, "manifest.json")))
+        assert manifest["target"].get("toolchain") == "fallback", manifest
+        info = _read(os.path.join(sdk_dir, "sdk-info.txt"))
+        assert "Toolchain:  fallback" in info, info
+        env = _read(os.path.join(sdk_dir, "environment-setup"))
+        assert "unsupported target stm32f103" in env, env
+
+
+def test_profile_non_cortex_arm_gets_arm_toolchain():
+    """ARM7TDMI / XScale parts have no Cortex core string but arm-none-eabi
+    is exactly their toolchain. pxa270 resolves a real board (xscale);
+    lpc2148 (arm7tdmi) gets the triplet with the board warning.
+    """
+    pxa = HardwareProfile()
+    pxa.mcu = "pxa270"
+    pxa.arch = "arm"
+    pxa.core = "xscale"
+    pxa.vendor = "Marvell"
+    pxa.mcu_family = "PXA27x"
+    lpc = HardwareProfile()
+    lpc.mcu = "lpc2148"
+    lpc.arch = "arm"
+    lpc.core = "arm7tdmi"
+    lpc.vendor = "NXP"
+    lpc.mcu_family = "LPC2000"
+
+    with tempfile.TemporaryDirectory() as out:
+        pxa_dir, pxa_ok, pxa_board = generate_sdk_from_profile(pxa, out, target="pxa270")
+        assert pxa_ok is True
+        assert pxa_board == "xscale", pxa_board
+        tc = _read(os.path.join(pxa_dir, "toolchain.cmake"))
+        assert "arm-none-eabi-gcc" in tc, tc
+        lpc_dir, lpc_ok, lpc_board = generate_sdk_from_profile(lpc, out, target="lpc2148")
+        assert lpc_ok is True
+        # eBoot ships an arm7tdmi core-class board upstream: stage 3 resolves it.
+        assert lpc_board == "arm7tdmi", lpc_board
+        tc = _read(os.path.join(lpc_dir, "toolchain.cmake"))
+        assert "arm-none-eabi-gcc" in tc, tc
+        eb = _read(os.path.join(lpc_dir, "eboot", "eboot_board.cmake"))
+        assert "FATAL_ERROR" not in eb, eb
+
+
+def test_core_named_boards_resolve_from_core_string():
+    """eBoot ships generic core-class ports: a chip with no chip-named row
+    gets the real board its core uses. Separator-insensitive and
+    microarch-suffix aware (arm926ej-s -> arm9, arm1176jzf-s -> arm11)."""
+    cases = {
+        "stm32f103": "cortex-m3",
+        "stm32f030": "cortex-m0",
+        "stm32l072": "cortex-m0+",
+        "lpc55s06": "cortex-m23",
+        "stm32u5": "cortex-m33",
+        "ra8m1": "cortex-m85",
+        "cortex_r52": "cortex-r52",
+        "rz_t1": "cortex-r4f",
+        "at91sam9g25": "arm926ej-s",
+        "bcm2835": "arm1176jzf-s",
+        "zynq7020": "cortex-a9",
+        "rk3588": "cortex-a76",
+        "sama5d36": "cortex-a5",
+        "omap5432": "cortex-a15",
+    }
+    for mcu, core in cases.items():
+        assert board_dir_for_core(core) is not None, mcu + " (" + core + ")"
+
+
+def test_board_stage_order_is_exact_then_mcu_then_core():
+    """Stage order must hold: a chip whose MCU row and core both resolve keeps
+    the MCU row; a chip with an exact EBOOT_BOARD target keeps that."""
+    p = HardwareProfile()
+    p.mcu = "stm32f401"
+    p.core = "cortex-m4"
+    assert _resolve_eboot_board_dir("stm32f401", p) == "stm32f4"
+    assert _resolve_eboot_board_dir("nrf52") == "nrf52"
+
+
+def test_wrong_width_rows_dropped():
+    """sifive_e (RV32) must not resolve to the 64-bit sifive_u board, and
+    ultrasparc (sparc64 arch) must not resolve to the 32-bit sparc board.
+    Both previously masked wrong-width rows that become real the moment an
+    rv32 toolchain lands."""
+    assert board_dir_for_mcu("sifive_e") is None
+    assert board_dir_for_mcu("sifive_e7") is None
+    assert board_dir_for_mcu("ultrasparc") is None
+    assert board_dir_for_mcu("ultrasparc_t") == "sparc64"
+
+
+def test_sdk_command_exits_nonzero_on_fallback_target():
+    """`ebuild sdk --target <unsupported>` must exit 1 like the pipeline path
+    (review 5111127987 finding 2): the same generator, two entry points, one
+    definition of success."""
+    from click.testing import CliRunner
+    from ebuild.cli.commands import cli
+
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as out:
+        result = runner.invoke(cli, ["sdk", "--target", "nrf52840",
+                                     "--output", out])
+        assert result.exit_code != 0, "fallback SDK must not exit 0"
+        assert "no cross-toolchain" in result.output, result.output
+
+
+def test_sdk_command_succeeds_on_known_target():
+    """`ebuild sdk --target nrf52` (a TARGET_ARCH key) still exits 0."""
+    from click.testing import CliRunner
+    from ebuild.cli.commands import cli
+
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as out:
+        result = runner.invoke(cli, ["sdk", "--target", "nrf52",
+                                     "--output", out])
+        assert result.exit_code == 0, result.output
+        assert "SDK generated" in result.output, result.output
+
+
+def test_mmu_class_rule_pinned():
+    """at91sam9g25 (ARM926) and bcm2835 (ARM11) sit on opposite sides of the
+    class split by rule: classic non-Cortex ARM -> mcu/bare-metal triplet,
+    Cortex-A/ARM11 application cores -> sbc/hosted triplet. The comment on
+    the ``arch == \"arm\"`` branch documents why; this pins the boundary so a
+    refactor cannot silently flip a side."""
+    a9 = HardwareProfile()
+    a9.arch = "arm"
+    a9.core = "arm926ej-s"
+    a11 = HardwareProfile()
+    a11.arch = "arm"
+    a11.core = "arm1176jzf-s"
+    ca9 = HardwareProfile()
+    ca9.arch = "arm"
+    ca9.core = "cortex-a9"
+    assert _info_from_profile(a9)["class"] == "mcu"
+    assert _info_from_profile(a9)["triplet"] == "arm-none-eabi"
+    assert _info_from_profile(a11)["class"] == "sbc"
+    assert _info_from_profile(a11)["triplet"] == "arm-linux-gnueabihf"
+    assert _info_from_profile(ca9)["class"] == "sbc"


### PR DESCRIPTION
# fix: derive SDK toolchain from detected profile

## What
`ebuild pipeline --board nrf52840` detects the chip (ARM Cortex-M4, Nordic) but then emits an x86_64 toolchain, so the firmware targets a desktop PC and never compiles for the chip. The SDK step now uses the detected profile, so the toolchain matches the hardware.

## Why
Step 4 of `_run_pipeline_steps` called `generate_sdk(board.lower(), ...)`, passing the board *name string*, not the profile. `nrf52840` is not a `TARGET_ARCH` key, so it fell back to x86_64. The analyzer had already answered the question; the build step discarded it.

## How
Added `generate_sdk_from_profile(profile, output_dir, target=None)`:
1. **Known target wins.** If the caller-supplied target (the board string the pipeline resolved) is a `TARGET_ARCH` key, use that canonical mapping exactly as the legacy `generate_sdk` would. Every supported board is byte-identical to the pre-fix behavior.
2. **Unknown chip, derive from profile.** The **architecture** is tested before the core, so 64-bit ARM (`arch` = `aarch64`/`arm64`) wins over a Cortex-A core string, while 32-bit Cortex-A / ARM11 parts keep `arm-linux-gnueabihf` + `class: sbc`; classic ARM7/ARM9/StrongARM/XScale parts (`arch` = `arm`, no Cortex core) get `arm-none-eabi` + `class: mcu`; AArch64 / RISC-V map to their shipped triplets. `riscv32` and other architectures with no shipped toolchain return `None` and keep the honest x86_64 fallback.
3. **eBoot board resolves from the profile — including eBoot's core-class ports.** The resolver (`_resolve_eboot_board_dir`) is three-stage: (1) exact target-name match in `EBOOT_BOARD`; (2) longest-prefix-first MCU match via one shared public helper (`board_dir_for_mcu`) over a precomputed list — the flagship `nrf52840` -> `nrf52`, and `esp32c3`/`esp32s3`/`ultrasparc_t` are not shadowed by their shorter family rows; (3) a **core-class match** against the 58 generic board ports eBoot upstream actually ships (`cortex_m3`, `arm9`, `cortex_a76`, ...), separator-insensitive and microarch-suffix-aware (`arm926ej-s` -> `arm9`, `arm1176jzf-s` -> `arm11`, `cortex-r4f` -> `cortex_r4`). So `stm32f103` gets the real `cortex_m3` board its core uses, not a false "no board" — previously 28 analyzer-known parts were told eBoot ships nothing while the port was on disk. Wrong-width rows are dropped, not resolved: `sifive_e` (RV32) no longer maps to the 64-bit `sifive_u` board and bare `ultrasparc` no longer maps to the 32-bit `sparc` board. Stage 3 is last, so no previously-resolving target changes. The per-chip MEMORY block is still gated on an exact target match only (a family sibling gets board vars, never a foreign linker script).
4. **`ebuild sdk --target` exits non-zero on a fallback SDK.** The pipeline path raised on a toolchain miss; the `ebuild sdk --target` path reported success for the same artifact. Both now gate identically (`TARGET_ARCH` membership): an unsupported target prints the error and exits 1, a known target still exits 0. No generator signature changed, so the pinned fallback-content tests are untouched.
5. **Class rule is explicit.** `class` describes the EoS payload tier, not the bootloader (eBoot itself always builds bare-metal): classic non-Cortex ARM (ARM7/ARM9/StrongARM/XScale) -> `arm-none-eabi` + `class: mcu`; Cortex-A/ARM11 application cores -> hosted triplet + `class: sbc` (Linux payload). Documented in-code and pinned by a test so a refactor cannot flip a side silently.
6. **Fail-closed, end to end — on the toolchain, not the board.** A toolchain miss raises in pipeline step 4 (`RuntimeError` → exit 1 via the existing handler) and is marked on every SDK surface (`manifest.json` `target.toolchain: fallback`, a `Toolchain: fallback` line in `sdk-info.txt`, a `WARNING` echo in `environment-setup`/`.bat`, plus the `FATAL_ERROR` in `eboot_board.cmake`). A *board* miss with a good toolchain warns and continues — the 24 analyzer-known parts with correct derived toolchains (e.g. `stm32f103` → `arm-none-eabi`) complete the pipeline exactly as `master` did, while any consumer that actually needs the board still fails by name. Both warnings name which half missed. `toolchain.cmake` content itself is untouched, so the documented legacy x86_64 fallback still stands. The legacy `generate_sdk` passes `toolchain_ok=target in TARGET_ARCH`, so an unmapped name gets the same honest labels.
7. **Tier direction.** `MCU_TO_EBOOT_BOARD` lives in `ebuild/sdk_generator.py` (Tier-1); `EosProjectGenerator` (the AI-assist subpackage) holds a class-attribute alias importing it from there, so the dependency points down. `import ebuild.sdk_generator` loads zero `eos_ai`/`llm` modules.
8. **No duplicate header.** The SDK no longer emits its own `eos_product_enables.h`: `EosConfigGenerator` already writes the identical `EOS_ENABLE_*` block into `eos_product_config.h` from the same `profile.get_eos_enables()`, and nothing consumed the SDK's copy. One source of truth, no drift. The board-onboarding guide (`docs/guides/adding_a_board.md` Step 7) and the alignment doc (`core/eos/docs/three-way-alignment.md`) now point at the table's real home.

**Note (behaviour change, stated honestly):** for a target *outside* `TARGET_ARCH`, the legacy `generate_sdk` wrote `EBOOT_BOARD x86`, whereas this path writes no eboot board at all (fail-loud) plus honest fallback labels. Known `TARGET_ARCH` targets are byte-identical to legacy, including their eboot board and linker scripts. Likewise, `ebuild pipeline --board <chip-with-no-toolchain>` now fails with exit 1 where it previously printed success with an x86_64 SDK — that is the point of the fix, but it is a behaviour change and it is stated here. Chips with a good toolchain and no board (e.g. `stm32f103`) complete exactly as before.

**F1 deferral (per architecture review):** making the legacy `ebuild sdk --target <name>` path also resolve via the profile is a separate behaviour change — it touches every unmapped target and retires `test_sdk_from_name_falls_back_to_x86_64` — so it is scoped to its own follow-up PR, not this one.

## Test plan (commands + results, executed)
```
PYTHONPATH= python -m pytest tests/unit/test_sdk_from_profile.py -q
31 passed in 2.3s
```
The 31 tests cover: legacy name fallback (`test_sdk_from_name_falls_back_to_x86_64`), nrf52840 profile (`test_sdk_from_profile_nrf52840`), the pipeline regression guard (`test_pipeline_sdk_matches_detected_profile`), raspi4 aarch64 preservation (`test_pipeline_sdk_raspi4_stays_aarch64`), unmapped MCU skipping a foreign linker script (`test_detected_unmapped_mcu_skips_foreign_linker_script`), unmapped MCU emitting no x86 eboot board (`test_unmapped_mcu_emits_no_x86_eboot_board`), unknown-MCU fallback (`test_sdk_from_profile_unknown_mcu_uses_fallback`), known-target byte-identical matrix (`test_known_targets_do_not_regress_through_pipeline`), 64-bit ARM ordering (`test_profile_aarch64_core_cortex_a72_is_64bit_toolchain`), riscv64 class (`test_profile_riscv64_is_sbc_class`), riscv32 honest fallback (`test_profile_riscv32_uses_honest_fallback`), eboot-key shape (`test_eboot_key_is_target_name_or_none`), nrf52840->nrf52 board via MCU prefix (`test_pipeline_nrf52840_gets_eboot_nrf52`), stm32f103 fail-closed (`test_stm32f103_still_no_eboot_and_fails_closed`), RISC-V alternate-spelling guard (`test_riscv_alt_spelling_falls_back`), vendor threading (`test_vendor_threaded_from_profile`), family sibling never inheriting a flagship memory map (`test_family_sibling_does_not_inherit_flagship_memory_map`), toolchain-miss fail-closed despite a resolved board (`test_toolchain_miss_fails_closed_despite_resolved_board`), fallback marked on every surface (`test_toolchain_miss_is_marked_fallback_everywhere`), no markers on supported targets (`test_supported_target_has_no_fallback_markers`), the status triple (`test_generate_sdk_from_profile_returns_status_triple`), longest-prefix resolution (`test_prefix_scan_prefers_longest_match`), pipeline completing for a good toolchain with a missing board (`test_pipeline_completes_for_good_toolchain_missing_board`), legacy fallback labels (`test_legacy_name_path_marks_fallback_on_all_surfaces`), classic-ARM toolchain derivation (`test_profile_non_cortex_arm_gets_arm_toolchain`), core-class board resolution from the core string (`test_core_named_boards_resolve_from_core_string`), stage-order pinning (`test_board_stage_order_is_exact_then_mcu_then_core`), wrong-width rows dropped (`test_wrong_width_rows_dropped`), the `sdk --target` exit-status gate (`test_sdk_command_exits_nonzero_on_fallback_target`, `test_sdk_command_succeeds_on_known_target`), and the MMU class-rule boundary (`test_mmu_class_rule_pinned`).

Full unit suite (this branch): `374 passed, 2 skipped` (3 unrelated env failures: `test_footprint` needs an external `size` tool; `test_version_fallback` is an untracked file from a separate branch and is not in this PR). Rest of the tree (`tests/`, minus unit): `203 passed, 4 skipped`; `tests/ebuild/test_build_dir_resolution.py` cannot even be collected on this Windows box (env-only, fails identically on master in CI-equivalent envs).

14-target pipeline matrix (ran it, full file comparison including `.ld` files): every `TARGET_ARCH` target produces byte-identical output through the pipeline vs legacy `generate_sdk` — **0 regressions**, including the six targets the analyzer gives no `mcu` for (raspi3, raspi4, vexpress, riscv_virt, malta, qemu_virt). `rp2040` (board -> `samd51`) keeps its exact-target `eboot_rp2040.ld` in both paths — unchanged. Verified by execution: `stm32f401`/`nrf52810`/`stm32h750` get board vars and no `.ld`; a detected Xtensa part gets `x86_64` + `FATAL_ERROR` + fallback markers on all surfaces and the pipeline raises `RuntimeError` (exit 1); `stm32f103` gets `arm-none-eabi` + the real `cortex_m3` board and the pipeline completes; `nrf52840` pipeline succeeds; `atmega328p` (no toolchain, no board) raises with the "no cross-toolchain" diagnostic.

## Out of scope
The image step and budget checks are separate issues. The SDK's `toolchain.cmake` is written for `environment-setup` consumers; `_run_cmake_build` still passes `EOS_BOARD`/`EOS_ARCH`/`EOS_CORE`, not `CMAKE_TOOLCHAIN_FILE`, so the pipeline's own build step does not yet consume it — noted so this is not mistaken for closing the cross-compilation gap. Bare-metal `CMAKE_SYSTEM_NAME` configuration (so `cmake` accepts the generated toolchain) is a pre-existing gap in its own PR. F1 (profile resolution in the legacy `ebuild sdk --target` path) is deferred to its own PR per the architecture review. The §22 hardware-tier representation proposal lives in the reviewer's `.ai/autoreview/proposals/`, not in this PR.

## Risks
Medium, scoped to SDK generation. Detected ARM/AArch64/RISC-V chips now get the right toolchain; a chip with no toolchain fails the pipeline with exit 1; a chip with a toolchain but no board completes with a warning and a board-level `FATAL_ERROR` for consumers that need it; known targets unchanged. No public API changed (legacy `generate_sdk` still returns the dir). No CI run has executed on this head — every figure above is from the author's machine.
