### PR TITLE
Fix compiler-dependent tests on systems without GCC

### DIFF
--- a/tests/ebuild/test_build_dir_resolution.py
+++ b/tests/ebuild/test_build_dir_resolution.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import shutil
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
@@ -243,7 +244,7 @@ def test_configure_and_build_from_outside_agree_on_the_build_dir(
 
 
 @pytest.mark.skipif(
-    subprocess.run(["gcc", "--version"], capture_output=True).returncode != 0,
+   shutil.which("gcc") is None,
     reason="needs a working gcc to link the executable",
 )
 def test_end_to_end_build_from_outside_produces_the_binary(tmp_path, monkeypatch):

--- a/tests/unit/test_footprint.py
+++ b/tests/unit/test_footprint.py
@@ -15,6 +15,7 @@ the two tools disagree about what "flash" means:
 """
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -58,6 +59,9 @@ class TestAccounting:
 
 class TestMeasure:
     def test_measures_a_real_binary(self, tmp_path):
+        if shutil.which("gcc") is None:
+            pytest.skip("needs a working gcc to compile the test binary")
+
         src = tmp_path / "m.c"
         src.write_text("static char buf[4096];\nint main(void){return buf[0];}\n")
         # gcc on Windows appends .exe when -o names no extension, so the


### PR DESCRIPTION
## Summary

Fix compiler-dependent tests so they skip cleanly when GCC is unavailable instead of raising FileNotFoundError.

## Type of Change

- [x] fix — Bug fix
- [x] test — Add or fix tests

## Problem

The affected tests invoked `gcc` directly. On systems where GCC is not installed, this caused FileNotFoundError and made the test suite fail.

## Solution

Check whether GCC is available using shutil.which("gcc"). If it is unavailable, the compiler-dependent test is skipped with a clear reason.

## Testing

Full test suite:

555 passed, 6 skipped, 0 failed

The GCC-dependent tests now skip cleanly on the current Windows environment.