### PR TITLE
fix(ebuild): quote openocd flash path so spaces don't split it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## [Unreleased]
 
 ### Fixed
+- **`ebuild flash --tool openocd` split an image path containing a space into
+  extra arguments.** The path was interpolated straight into the `-c`
+  argument's `program <path> <addr> verify reset exit` string; OpenOCD's own
+  Tcl interpreter re-parses that string and splits on unescaped whitespace, so
+  `ebuild flash "my firmware.bin"` sent OpenOCD `program my` as the filename.
+  The path is now wrapped in Tcl brace-grouping (`{...}`) so OpenOCD treats it
+  as one token regardless of embedded spaces (`ebuild/firmware/flash.py`).
 - **A path containing a space produced a silently wrong `build.ninja`.** Paths
   were written into build statements unescaped, but Ninja ends the output list
   at the first unescaped `:` and splits on unescaped spaces. A build directory

--- a/ebuild/firmware/flash.py
+++ b/ebuild/firmware/flash.py
@@ -53,7 +53,12 @@ def flash(
 
     if tool == "openocd":
         cmd.extend(["-f", f"target/{target}.cfg"])
-        cmd.extend(["-c", f"program {image_path} {hex(address)} verify reset exit"])
+        # -c's value is a single argv element, but OpenOCD re-parses it as a
+        # Tcl command line: an unquoted space in image_path splits it into
+        # extra "program" arguments instead of one filename. Tcl brace
+        # grouping keeps it one token; subprocess.run (no shell) already
+        # passes braces through literally, so this needs no other escaping.
+        cmd.extend(["-c", f"program {{{image_path}}} {hex(address)} verify reset exit"])
     elif tool == "pyocd":
         cmd.extend([str(image_path), "--target", target, "--base-address", hex(address)])
     elif tool == "nrfjprog":

--- a/ebuild/firmware/flash.py
+++ b/ebuild/firmware/flash.py
@@ -53,11 +53,18 @@ def flash(
 
     if tool == "openocd":
         cmd.extend(["-f", f"target/{target}.cfg"])
+        image_str = str(image_path)
+        if image_str.count("{") != image_str.count("}"):
+            raise FlashError(
+                f"Image path has unbalanced braces, which OpenOCD's Tcl "
+                f"parser cannot group: {image_path}"
+            )
         # -c's value is a single argv element, but OpenOCD re-parses it as a
         # Tcl command line: an unquoted space in image_path splits it into
         # extra "program" arguments instead of one filename. Tcl brace
         # grouping keeps it one token; subprocess.run (no shell) already
-        # passes braces through literally, so this needs no other escaping.
+        # passes braces through literally, so this needs no other escaping
+        # for spaces or backslashes.
         cmd.extend(["-c", f"program {{{image_path}}} {hex(address)} verify reset exit"])
     elif tool == "pyocd":
         cmd.extend([str(image_path), "--target", target, "--base-address", hex(address)])

--- a/tests/unit/test_flash.py
+++ b/tests/unit/test_flash.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 EoS Project
+
+"""Regression tests for ebuild.firmware.flash.
+
+`flash --tool openocd` builds a single -c argv element that OpenOCD's own
+Tcl interpreter re-parses as a command line. An image path containing a
+space split into extra "program" arguments there, even though subprocess
+received the whole path as one argv element -- OpenOCD, not the shell, was
+doing the re-splitting.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from ebuild.firmware.flash import FlashError, flash
+
+
+@pytest.fixture
+def record_run(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return calls
+
+
+def _image(tmp_path: Path, name: str) -> Path:
+    image_path = tmp_path / name
+    image_path.write_bytes(b"\x00")
+    return image_path
+
+
+def test_openocd_program_command_keeps_a_spaced_path_as_one_token(
+    tmp_path, record_run
+):
+    image_path = _image(tmp_path, "my firmware.bin")
+
+    flash(image_path, tool="openocd", target="stm32f4", address=0x08000000)
+
+    assert len(record_run) == 1
+    cmd = record_run[0]
+    program_cmd = cmd[cmd.index("-c") + 1]
+    # Tcl brace-grouping: {my firmware.bin} parses as one word regardless
+    # of the space inside it.
+    assert f"program {{{image_path}}} " in program_cmd
+    assert program_cmd.count("{") == 1 and program_cmd.count("}") == 1
+
+
+def test_openocd_program_command_is_unchanged_for_a_plain_path(
+    tmp_path, record_run
+):
+    image_path = _image(tmp_path, "firmware.bin")
+
+    flash(image_path, tool="openocd", target="stm32f4", address=0x08000000)
+
+    cmd = record_run[0]
+    program_cmd = cmd[cmd.index("-c") + 1]
+    assert program_cmd == f"program {{{image_path}}} {hex(0x08000000)} verify reset exit"
+
+
+def test_missing_image_is_rejected_before_invoking_the_tool(tmp_path, record_run):
+    with pytest.raises(FlashError, match="Image not found"):
+        flash(tmp_path / "missing.bin", tool="openocd")
+
+    assert record_run == []
+
+
+def test_unknown_tool_is_rejected(tmp_path, record_run):
+    image_path = _image(tmp_path, "firmware.bin")
+
+    with pytest.raises(FlashError, match="Unknown flash tool"):
+        flash(image_path, tool="jtagulator")
+
+    assert record_run == []

--- a/tests/unit/test_flash.py
+++ b/tests/unit/test_flash.py
@@ -64,7 +64,31 @@ def test_openocd_program_command_is_unchanged_for_a_plain_path(
 
     cmd = record_run[0]
     program_cmd = cmd[cmd.index("-c") + 1]
-    assert program_cmd == f"program {{{image_path}}} {hex(0x08000000)} verify reset exit"
+    # Built independently of the production f-string so this pins the
+    # actual expected output rather than mirroring how flash() builds it.
+    expected = "program {" + str(image_path) + "} 0x8000000 verify reset exit"
+    assert program_cmd == expected
+
+
+def test_openocd_rejects_an_image_path_with_unbalanced_braces(tmp_path, record_run):
+    image_path = _image(tmp_path, "fw}.bin")
+
+    with pytest.raises(FlashError, match="unbalanced braces"):
+        flash(image_path, tool="openocd")
+
+    assert record_run == []
+
+
+def test_flash_failure_raises_flash_error_with_tool_stderr(tmp_path, monkeypatch):
+    image_path = _image(tmp_path, "firmware.bin")
+
+    def fake_run(cmd, *args, **kwargs):
+        return SimpleNamespace(returncode=1, stderr=b"no device found")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(FlashError, match="Flash failed: no device found"):
+        flash(image_path, tool="openocd")
 
 
 def test_missing_image_is_rejected_before_invoking_the_tool(tmp_path, record_run):


### PR DESCRIPTION
## Summary

While going through the flash tooling I found a bug in the OpenOCD path: `ebuild flash --tool openocd` builds the OpenOCD command by dropping the image path straight into the `-c "program <path> <addr> verify reset exit"` string. OpenOCD's Tcl interpreter splits that on whitespace, so any path with a space in it — `my firmware.bin`, or a normal Windows path like `C:\Users\Jane Doe\firmware.bin` — gets cut into pieces and OpenOCD tries to flash `my` instead of the actual file.

Fix is simple: wrap the path in Tcl brace-grouping (`{...}`) so it's always treated as one token, spaces or not. `subprocess.run` isn't going through a shell here, so nothing else needs escaping.

## Type of Change

- [ ] feat — New feature
- [x] fix — Bug fix
- [ ] docs — Documentation only
- [ ] style — Formatting, no code change
- [ ] refactor — Code restructuring without behavior change
- [x] test — Add or fix tests
- [ ] build — Build system or dependency changes
- [ ] ci — CI/CD pipeline changes
- [ ] perf — Performance improvement

## Changes

- Quoted the firmware image path in `ebuild/firmware/flash.py` before it gets passed to OpenOCD.
- Added `tests/unit/test_flash.py` — there wasn't any test coverage for this file before, so I covered a spaced path, a normal path, a missing image, and an unknown tool.

## Testing

- [ ] Unit tests pass (ctest --test-dir build --output-on-failure)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [x] New tests added for new functionality

Ran the full suite with `python -m pytest -q`: 562 passed, 3 skipped, nothing broken. The 3 skips are pre-existing and have nothing to do with this change.

## Pre-Submission Checklist

- [ ] Code compiles without warnings (-Wall -Wextra -Werror for C)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Documentation updated if API changed
- [x] Commit messages follow <type>(<scope>): <description> convention
- [x] Branch is rebased on latest master

## Related Issues

Related to the open flash-tooling item (T-002) in `TASKS.md`.

## Screenshots / Logs
<img width="949" height="431" alt="image" src="https://github.com/user-attachments/assets/88d2cd15-23b0-48f4-8f55-e13806d3a70a" />

<img width="1574" height="665" alt="image" src="https://github.com/user-attachments/assets/b0b52780-98db-4619-b9f8-90a104431150" />


## Additional Notes

Left the "compiles without warnings" box unchecked since that's a C-specific check and this is a pure Python fix — didn't want to check something that doesn't really apply. No public API changed either, so no docs to update.