### PR TITLE
fix(deps): stop DepsManager setters mutating the shared DEFAULT_CONFIG template

### DIFF
--- a/ebuild/deps/manager.py
+++ b/ebuild/deps/manager.py
@@ -10,6 +10,7 @@ locations instead of each command re-cloning into temp directories.
 
 from __future__ import annotations
 
+import copy
 import os
 import subprocess
 import warnings
@@ -70,17 +71,20 @@ class DepsManager:
         if EBUILD_CONFIG_PATH.exists():
             with open(EBUILD_CONFIG_PATH, "r", encoding="utf-8") as f:
                 data = yaml.safe_load(f) or {}
-            # Merge missing keys from defaults
+            # Merge missing keys from defaults. Deep-copied: setup(),
+            # set_url(), set_branch() and link() mutate these nested dicts
+            # in place, and an aliased default would leak one instance's
+            # edits into DEFAULT_CONFIG for the rest of the process.
             for key, val in DEFAULT_CONFIG.items():
                 if key not in data:
-                    data[key] = val
+                    data[key] = copy.deepcopy(val)
                 elif key == "repos" and isinstance(val, dict):
                     for rname, rval in val.items():
                         if rname not in data["repos"]:
-                            data["repos"][rname] = rval
+                            data["repos"][rname] = copy.deepcopy(rval)
             return data
 
-        self._config = dict(DEFAULT_CONFIG)
+        self._config = copy.deepcopy(DEFAULT_CONFIG)
         self.save_config()
         return self._config
 

--- a/tests/ebuild/test_deps_manager.py
+++ b/tests/ebuild/test_deps_manager.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from ebuild.deps import DEFAULT_CONFIG
 from ebuild.deps.manager import DepsManager, SIBLING_DIR_NAMES
 
 
@@ -76,3 +77,25 @@ def test_sibling_eboot_missing_returns_none(isolated_deps, monkeypatch):
     resolved = DepsManager().get_repo_path("eboot", project_dir=project)
 
     assert resolved is None
+
+
+def test_setters_do_not_mutate_module_defaults(isolated_deps):
+    """In-place config edits must not leak into the shared DEFAULT_CONFIG.
+
+    load_config() used to alias the nested default repo dicts instead of
+    copying them, so set_branch() on one DepsManager rewrote the module-level
+    template — and every later instance in the process inherited the edit as
+    its 'default'.
+    """
+    mgr = DepsManager()
+    mgr.set_branch("eos", "dev")
+    mgr.set_url("eboot", "https://example.invalid/eboot.git")
+
+    assert DEFAULT_CONFIG["repos"]["eos"]["branch"] == "master"
+    assert DEFAULT_CONFIG["repos"]["eboot"]["url"].endswith("/eBoot.git")
+
+    # A fresh instance starting from a clean config must not see them either.
+    fresh = DepsManager()
+    fresh._config = fresh.load_config()
+    assert fresh.config["repos"]["eos"]["branch"] == "dev"  # persisted for us
+    assert DEFAULT_CONFIG["repos"]["eos"]["branch"] == "master"  # not for all


### PR DESCRIPTION
## Issue

`DepsManager.load_config()` merged `DEFAULT_CONFIG` into the loaded config by reference (`data[key] = val`, `data["repos"][rname] = rval`) and seeded first-run configs with a shallow `dict(DEFAULT_CONFIG)`. The nested per-repo dicts in every instance's config were therefore the same objects as the module-level template. Since `setup()`, `link()`, `set_url()` and `set_branch()` all mutate those dicts in place, one instance's edits silently rewrote the process-wide defaults that every later instance (and any freshly written `~/.ebuild/config.yaml`) inherited.

## Approach

Deep-copy the default values at each merge point in `load_config()`. No behavioral change for the normal single-instance flow, and persisted configs are unaffected.

## Testing / validation

- Static analysis of all `DEFAULT_CONFIG` consumers and every `self._config` mutation site.
- Added `test_setters_do_not_mutate_module_defaults` to `tests/ebuild/test_deps_manager.py` (reusing the existing `isolated_deps` fixture): asserts the template stays pristine after `set_branch`/`set_url` while the instance's own config keeps and persists the edits.
- The test was written for CI to run; it was not executed locally.

## Limitations

The fix guards the default-template aliasing only; a caller who mutates `manager.config` directly can still alias into the live instance config (pre-existing API surface, unchanged here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
