### PR TITLE
fix: restore recipe parser import

### DIFF
--- a/ebuild/packages/recipe.py
+++ b/ebuild/packages/recipe.py
@@ -125,7 +125,7 @@ def _parse_string_list(
     return list(value)
 
 
-def _parse_recipe(
+def parse_recipe(
     raw: Dict[str, Any],
     source_path: Optional[Path] = None,
 ) -> PackageRecipe:

--- a/tests/ebuild/test_package_recipe.py
+++ b/tests/ebuild/test_package_recipe.py
@@ -5,7 +5,12 @@
 
 import pytest
 
-from ebuild.packages.recipe import RecipeError, load_recipe_from_string
+from ebuild.packages.recipe import (
+    RecipeError,
+    _parse_recipe,
+    load_recipe_from_string,
+    parse_recipe,
+)
 
 
 BASE_RECIPE = """
@@ -14,6 +19,11 @@ version: 1.0.0
 url: https://example.com/demo.tar.gz
 checksum: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 """
+
+
+def test_parse_recipe_public_name_preserves_legacy_alias():
+    """The public parser keeps the legacy private alias."""
+    assert _parse_recipe is parse_recipe
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Define the public parse_recipe function before retaining the _parse_recipe compatibility alias.
- Add a regression test covering both parser names.

## Verification

- py -m pytest -q tests/ebuild/test_package_recipe.py tests/ebuild/test_smoke_imports.py (64 passed)
- py -m flake8 ebuild/packages/recipe.py tests/ebuild/test_package_recipe.py (existing line-length and final-newline findings remain)