### PR TITLE
fix(packages): add PackageRecipe serialization

### DIFF
--- a/ebuild/packages/recipe.py
+++ b/ebuild/packages/recipe.py
@@ -89,6 +89,23 @@ class PackageRecipe:
                 f"Must be one of {self.VALID_BUILD_SYSTEMS}."
             )
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the recipe using the canonical YAML recipe schema."""
+        return {
+            "package": self.name,
+            "version": self.version,
+            "description": self.description,
+            "license": self.license,
+            "url": self.url,
+            "checksum": self.checksum,
+            "build": self.build_system,
+            "dependencies": list(self.dependencies),
+            "patches": list(self.patches),
+            "configure_args": list(self.configure_args),
+            "build_args": list(self.build_args),
+            "install_args": list(self.install_args),
+        }
+
 
 def _parse_string_list(
     raw: Dict[str, Any],

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -1,0 +1,21 @@
+from ebuild.packages.recipe import PackageRecipe
+
+
+def test_package_recipe_to_dict_uses_canonical_schema():
+    recipe = PackageRecipe(
+        name="demo",
+        version="1.0.0",
+        url="https://example.com/demo.tar.gz",
+        build_system="cmake",
+        dependencies=["dep"],
+    )
+
+    data = recipe.to_dict()
+
+    assert data["package"] == "demo"
+    assert data["version"] == "1.0.0"
+    assert data["url"] == "https://example.com/demo.tar.gz"
+    assert data["build"] == "cmake"
+    assert data["dependencies"] == ["dep"]
+    assert "name" not in data
+    assert "build_system" not in data


### PR DESCRIPTION
## Summary

Fix package index synchronization failing with `AttributeError` when caching validated package recipes.

`IndexSyncManager.sync()` calls `PackageRecipe.to_dict()`, but `PackageRecipe` did not implement that method. This PR adds canonical recipe serialization using the existing YAML schema and adds regression coverage.

## Type of Change

<!-- Check all that apply -->

- [ ] eat — New feature
- [x] fix — Bug fix
- [ ] docs — Documentation only
- [ ] style — Formatting, no code change
- [ ] 
efactor — Code restructuring without behavior change
- [x] test — Add or fix tests
- [ ] uild — Build system or dependency changes
- [ ] ci — CI/CD pipeline changes
- [ ] perf — Performance improvement

## Changes

- Added `PackageRecipe.to_dict()` to serialize package recipes using the canonical YAML schema.
- Added a regression test verifying that serialization uses external YAML keys such as `package` and `build` rather than internal model fields such as `name` and `build_system`.


## Testing

<!-- How was this tested? Which test suites were run? -->

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing performed
- [x] New tests added for new functionality

Tested with:

```bash
python -m pytest tests/unit/test_recipe.py tests/unit/test_index_sync.py -v
python -m pytest
```

## Pre-Submission Checklist

- [x] Code compiles without warnings (-Wall -Wextra -Werror for C)
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Documentation updated if API changed
- [x] Commit messages follow <type>(<scope>): <description> convention
- [x] Branch is rebased on latest master


