### PR TITLE
fix(ebuild): preserve toolchain linker flags for shared libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
   `cjson` (v1.7.18), `nanopb` (v0.4.9.1), `lvgl` (v9.2.2), `tinyusb` (v0.18.0), and `unity` (v2.6.1).
 
 ### Fixed
+- Shared-library Ninja link commands now preserve toolchain `extra_ldflags`
+  and `sysroot`, before target linker flags and package library paths, matching
+  executable targets. Previously those toolchain settings were silently ignored.
 - **`ebuild test` now finds Windows test binaries.** The Ninja edge for a
   native `type: test` target already carried the platform suffix
   (`_exe_suffix()` names it `<name>.exe` on Windows), but `ebuild test`

--- a/TASKS.md
+++ b/TASKS.md
@@ -9,6 +9,62 @@ Status is one of: `todo`, `in-progress`, `blocked`, `review`, `done`.
 
 ## Active
 
+### T-119 — Preserve toolchain linker settings for shared libraries
+
+Owner: backend / testing
+Mode: Verification
+Status: review
+Depends on: none
+
+Goal: shared-library link commands honor the same toolchain settings as executables.
+
+Acceptance criteria:
+- Shared-library link flags include toolchain ldflags and sysroot before target ldflags and package library paths.
+- Generating multiple shared libraries does not mutate or leak flags between targets or into the toolchain.
+- A real Linux shared-library build honors toolchain `-Wl,--no-undefined`: a resolved source builds successfully and an unresolved source fails to link.
+
+Design: reuse the already-computed `_get_toolchain_ldflags()` result with list
+concatenation, matching executable handling. No API or dependency changes.
+Files in scope: `ebuild/build/ninja_backend.py`,
+`tests/unit/test_shared_library_toolchain.py`, `CHANGELOG.md`, `TASKS.md`.
+Other shared-library features and unrelated defects are out of scope.
+Risk: previously ignored linker options may now correctly reject invalid builds.
+Verification: new tests before/after the fix, full pytest suite, Ruff, mypy,
+Python package build, and the repository's CMake/CTest check.
+
+Handoff (planning/architecture -> implementation/testing): discovery found the
+shared-library branch initializes flags from the target alone. The executable
+branch already includes toolchain flags. Acceptance criteria are the three
+bullets above; all checks are NOT RUN. Next: write failing regressions, then fix.
+
+Verification results (Linux, Python 3.12):
+- PASS: all three new regression cases failed against the original backend,
+  then passed with the fix (`pytest tests/unit/test_shared_library_toolchain.py -q`).
+- PASS: independent reviewer repeated the focused tests (3 passed), found no
+  blocking issues, and confirmed all three acceptance criteria.
+- PASS: Ruff on both changed Python files; mypy on `ninja_backend.py`;
+  `python -m build --no-isolation` (sdist and wheel); `git diff --check`;
+  `yamllint .` (no YAML changes).
+- FAIL (pre-existing): full suite: `9 failed, 672 passed, 3 skipped in 51.88s`.
+  All nine failures are in `tests/unit/test_index_sync.py`:
+  `AttributeError: 'PackageRecipe' object has no attribute 'to_dict'`.
+  Reproduced the same nine failures in a detached baseline worktree at
+  `8b623d5` (9 failed, 13 passed in that module).
+- FAIL (pre-existing): repository-wide mypy reports the same missing
+  `PackageRecipe.to_dict` at `ebuild/packages/index_sync.py:354`.
+- FAIL (pre-existing): repository-wide Ruff reports F811 in
+  `tests/ebuild/test_build_dir_resolution.py`, W292 in
+  `tests/ebuild/test_package_recipe.py`, and two E402 findings in
+  `tests/unit/test_ci_gate.py`. These files are unchanged.
+- NOT RUN: CMake/CTest; `cmake: command not found` in this environment.
+- NOT RUN: real Windows/macOS linker execution and cross-compilation with an SDK.
+  Portable manifest tests cover sysroot emission; the compiler regression is
+  explicitly Linux/GCC-only.
+
+Handoff (verification -> maintainer): focused change independently reviewed;
+submission is for review, not a release. Remaining work: maintainer review/CI,
+with the unrelated baseline failures above tracked here for separate fixes.
+
 | ID | Task | Owner | Mode | Status | Depends on |
 |----|------|-------|------|--------|------------|
 | T-002 | Fix Windows Ninja test-target path parsing | backend | Maintenance | review | none |

--- a/ebuild/build/ninja_backend.py
+++ b/ebuild/build/ninja_backend.py
@@ -280,7 +280,7 @@ class NinjaBackend:
                     # get, which the rule preamble alone does not supply. The
                     # "build a shared object" flag itself lives in the
                     # link_shared rule, so it must not be repeated here.
-                    ldflags = list(target.ldflags)
+                    ldflags = toolchain_ldflags + list(target.ldflags)
                     libs = []
                     for pkg_name in target.uses:
                         pkg = self.package_paths.get(pkg_name)

--- a/tests/unit/test_shared_library_toolchain.py
+++ b/tests/unit/test_shared_library_toolchain.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 EoS Project
+
+"""Regression tests for toolchain settings in shared-library link commands."""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from ebuild.build.ninja_backend import NinjaBackend, PackagePaths
+from ebuild.build.toolchain import ResolvedToolchain
+from ebuild.cli.commands import cli
+from ebuild.core.config import ProjectConfig, TargetConfig
+
+
+@pytest.mark.parametrize("sysroot", [None, "/opt/target-sysroot"])
+def test_shared_link_preserves_toolchain_flags_without_mutation(tmp_path, sysroot):
+    toolchain = ResolvedToolchain(ldflags=["-Wl,--no-undefined"], sysroot=sysroot)
+    targets = [
+        TargetConfig(
+            name=name,
+            target_type="shared_library",
+            sources=[f"{name}.c"],
+            ldflags=[f"-Wl,-soname,lib{name}.so"],
+            uses=[name],
+        )
+        for name in ("first", "second")
+    ]
+    packages = {
+        name: PackagePaths(lib_dirs=[Path(f"vendor/{name}")], libraries=[name])
+        for name in ("first", "second")
+    }
+    config = ProjectConfig(name="libs", version="1.0", targets=targets)
+    NinjaBackend(config, tmp_path, toolchain, packages).generate()
+    manifest = (tmp_path / "build.ninja").read_text(encoding="utf-8")
+
+    for target in targets:
+        edge = next(
+            block for block in manifest.split("\n\n")
+            if ": link_shared " in block and f"lib{target.name}." in block
+        )
+        expected = ["-Wl,--no-undefined"]
+        if sysroot:
+            expected.append(f"--sysroot={sysroot}")
+        expected += target.ldflags + [f"-L{Path('vendor') / target.name}"]
+        assert edge.splitlines()[1:] == [
+            f"  ldflags = {' '.join(expected)}",
+            f"  libs = -l{target.name}",
+        ]
+        assert target.ldflags == [f"-Wl,-soname,lib{target.name}.so"]
+    assert toolchain.ldflags == ["-Wl,--no-undefined"]
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or shutil.which("gcc") is None,
+    reason="requires Linux and GCC for --no-undefined shared-library linking",
+)
+def test_cli_shared_library_honors_toolchain_no_undefined(tmp_path, monkeypatch):
+    pytest.importorskip("ninja", reason="ninja Python package not installed")
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "build.yaml").write_text(
+        "project:\n  name: shared-link-check\n  version: '1.0'\n"
+        "toolchain:\n  compiler: gcc\n"
+        "  extra_ldflags: ['-Wl,--no-undefined']\n"
+        "targets:\n  - name: example\n    type: shared_library\n"
+        "    sources: [example.c]\n    cflags: [-fPIC]\n",
+        encoding="utf-8",
+    )
+    source = tmp_path / "example.c"
+    source.write_text("int example(void) { return 42; }\n", encoding="utf-8")
+    runner = CliRunner()
+    good = runner.invoke(cli, ["build", "--backend", "ninja", "--build-dir", "good"])
+    assert good.exit_code == 0, good.output
+    assert (tmp_path / "good" / "libexample.so").is_file()
+
+    source.write_text(
+        "extern int missing_symbol(void);\n"
+        "int example(void) { return missing_symbol(); }\n",
+        encoding="utf-8",
+    )
+    # A separate output directory avoids timestamp-based incremental decisions.
+    bad = runner.invoke(cli, ["build", "--backend", "ninja", "--build-dir", "bad"])
+    assert bad.exit_code != 0, bad.output
+    assert "undefined reference" in bad.output, bad.output
+    assert "missing_symbol" in bad.output, bad.output


### PR DESCRIPTION
## Summary

Fix missing toolchain linker flags and sysroot when the Ninja backend links shared libraries. Shared-library targets now use the same computed toolchain settings as executable and test targets.

Implemented and tested with assistance from OpenAI Codex.

## Type of Change

- [x] fix — Bug fix
- [x] test — Add regression tests

## Changes

- Include `toolchain_ldflags` before target-specific linker flags in the shared-library branch of `ebuild/build/ninja_backend.py`.
- Add regression tests for linker flags, sysroot emission, flag ordering, and preservation of the original input lists.
- Add a Linux/GCC CLI regression test proving that `-Wl,--no-undefined` rejects an unresolved symbol.
- Add a CHANGELOG entry and retain the compact T-006 row in TASKS.md, as requested in review.

## Testing

The results below restore the original Linux/Python 3.12 verification record from commit `75d9249cebf639b986ec9032576cef70c515fdbd`, TASKS.md lines 39–66.

These are historical verification results, not a new test run during this description update. The backend code and regression tests are unchanged at commit `ed3a2eed4ff2d614f042db532700df1c217b5d4b`.

- [x] Regression tests added.
- [x] Focused regression tests passed in the original verification.
- [ ] Full repository suite passes — pre-existing failures documented below.
- [ ] Hosted CI successfully completed — not yet confirmed.

### Passing checks

- `pytest tests/unit/test_shared_library_toolchain.py -q`: all three regression cases failed against the original backend and passed with the fix.
- The original verification record reports that an independent reviewer repeated the focused tests: 3 passed.
- Ruff passed on both changed Python files.
- mypy passed on `ebuild/build/ninja_backend.py`.
- `python -m build --no-isolation` passed, producing an sdist and wheel.
- `git diff --check` passed.
- `yamllint .` passed; no YAML files were changed.

### Pre-existing failures

- Full pytest suite: 9 failed, 672 passed, 3 skipped in 51.88 seconds.
- All nine failures were in `tests/unit/test_index_sync.py`, reporting that `PackageRecipe` has no attribute `to_dict`.
- The same nine failures were reproduced in a detached baseline worktree at `8b623d5`: 9 failed and 13 passed in that module.
- Repository-wide mypy reported the same missing `PackageRecipe.to_dict` at `ebuild/packages/index_sync.py:354`.
- Repository-wide Ruff reported F811 in `tests/ebuild/test_build_dir_resolution.py`, W292 in `tests/ebuild/test_package_recipe.py`, and two E402 findings in `tests/unit/test_ci_gate.py`. These files are unchanged by this PR.

### Not run

- CMake/CTest: `cmake` was unavailable in the verification environment.
- Real Windows/macOS linker execution.
- Cross-compilation with an actual SDK/sysroot.

Portable manifest tests cover sysroot emission. The compiler-level regression is explicitly Linux/GCC-only.

## Related Issues

Fixes #139

## Additional Notes

The verification evidence is restored here in the PR description, while TASKS.md retains the compact task row requested in review.

No public API changes are introduced. Required CI checks and final maintainer review remain pending.