### PR TITLE
docs(governance): enforce linked issue policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,57 +2,56 @@
 
 <!-- Brief description of what this PR does. -->
 
-
 ## Type of Change
 
 <!-- Check all that apply -->
 
-- [ ] eat — New feature
-- [ ] ix — Bug fix
-- [ ] docs — Documentation only
-- [ ] style — Formatting, no code change
-- [ ] efactor — Code restructuring without behavior change
-- [ ] 	est — Add or fix tests
-- [ ] uild — Build system or dependency changes
-- [ ] ci — CI/CD pipeline changes
-- [ ] perf — Performance improvement
+- [ ] feat - New feature
+- [ ] fix - Bug fix
+- [ ] docs - Documentation only
+- [ ] style - Formatting, no code change
+- [ ] refactor - Code restructuring without behavior change
+- [ ] test - Add or fix tests
+- [ ] build - Build system or dependency changes
+- [ ] ci - CI/CD pipeline changes
+- [ ] perf - Performance improvement
 
 ## Changes
 
 <!-- List each change made in this PR -->
 
-- 
-- 
+-
+-
 
 ## Testing
 
 <!-- How was this tested? Which test suites were run? -->
 
-- [ ] Unit tests pass (ctest --test-dir build --output-on-failure)
+- [ ] Unit tests pass (`ctest --test-dir build --output-on-failure`)
 - [ ] Integration tests pass
 - [ ] Manual testing performed
 - [ ] New tests added for new functionality
 
 ## Pre-Submission Checklist
 
-- [ ] Code compiles without warnings (-Wall -Wextra -Werror for C)
+- [ ] Code compiles without warnings (`-Wall -Wextra -Werror` for C)
 - [ ] All existing tests pass
 - [ ] New tests added for new functionality
 - [ ] Documentation updated if API changed
-- [ ] Commit messages follow <type>(<scope>): <description> convention
-- [ ] Branch is rebased on latest master
+- [ ] Commit messages follow the `<type>(<scope>): <description>` convention
+- [ ] Branch is rebased on latest `master`
+- [ ] This PR links a real issue in this repository with a closing keyword
 
-## Related Issues
+## Related Issue
 
-<!-- Reference related issues: Closes #XX, Fixes #YY -->
+<!-- Required: use an automatic closing keyword for an issue in this repository. -->
 
+Fixes #<issue-number>
 
 ## Screenshots / Logs
 
-<!-- If applicable, add screenshots or relevant log output -->
-
+<!-- If applicable, add screenshots or relevant log output. -->
 
 ## Additional Notes
 
-<!-- Any other context reviewers should know -->
-
+<!-- Any other context reviewers should know. -->

--- a/.github/workflows/linked-issue.yml
+++ b/.github/workflows/linked-issue.yml
@@ -1,0 +1,16 @@
+name: Linked issue policy
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  policy:
+    uses: embeddedos-org/.github/.github/workflows/linked-issue-policy.yml@92cb596c773496ec4df76717e8acf0e6b7700f73
+    with:
+      policy_ref: 92cb596c773496ec4df76717e8acf0e6b7700f73

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,42 @@ One rule is structural rather than stylistic: **whoever implements does not
 approve.** Review is a separate role because self-review reliably misses the
 thing the implementer already believes is correct.
 
+## Repository map
+
+- `ebuild/` is the Python package. Keep CLI wiring in `ebuild/cli/`, backend
+  selection and execution in `ebuild/build/`, dependency and package behavior
+  in `ebuild/deps/` and `ebuild/packages/`, and image or firmware workflows in
+  `ebuild/system/` and `ebuild/firmware/`.
+- `core/` contains vendored native EoS and eBoot components. Changes there need
+  the component's CMake tests in addition to the Python suite.
+- `recipes/`, `layers/`, `hardware/`, and `templates/` are user-facing build
+  inputs. Preserve their schemas and add a focused parser, resolver, or
+  generated-output test when behavior changes.
+- `docs/` is the MkDocs source. `docs/wiki/` mirrors the six published GitHub
+  Wiki pages; keep those pages aligned when their shared guidance changes.
+- `tests/ebuild/` and `tests/unit/` cover the Python tool, while
+  `tests/functional/`, `tests/performance/`, and native `core/**/tests/` cover
+  broader behavior. Do not use `tests_backup/` as the validation target.
+
+## Working in this repository
+
+1. Read `README.md`, `CONTRIBUTING.md`, and the nearest component files before
+   editing. Keep changes within the requested subsystem.
+2. Install the Python development environment with
+   `python -m pip install -e ".[dev]"` when dependencies are not already
+   available.
+3. Run focused tests for the changed behavior, then run
+   `python -m pytest tests/ -v --tb=short` when the environment supports the
+   full suite.
+4. Run `ruff check .` for Python changes. For native changes, configure with
+   `cmake -S . -B build -DEOS_BUILD_TESTS=ON`, build with `cmake --build build`,
+   and run `ctest --test-dir build --output-on-failure`.
+5. Validate changed YAML and Markdown with the repository tooling, and always
+   run `git diff --check` before committing.
+6. Follow the DCO and conventional commit requirements in `CONTRIBUTING.md`.
+   Pull requests must use a closing keyword such as `Fixes #123` for a real
+   issue in this repository.
+
 ## Planner — [.ai/planner.md](./.ai/planner.md)
 
 - Understand the request.

--- a/docs/wiki/Development.md
+++ b/docs/wiki/Development.md
@@ -1,0 +1,27 @@
+# Development
+
+## Contribution source of truth
+
+[CONTRIBUTING](https://github.com/embeddedos-org/ebuild/blob/master/CONTRIBUTING.md)
+
+Before proposing a change, also review the [README](https://github.com/embeddedos-org/ebuild/blob/master/README.md). Keep changes scoped, add tests appropriate to the affected behavior, and follow the repository's current automation and review requirements.
+
+## Build and dependency inputs found
+
+`CMakeLists.txt`, `Dockerfile`, `core/eboot/CMakeLists.txt`, `core/eboot/requirements.txt`, `core/eboot/tests/CMakeLists.txt`, `core/eos/CMakeLists.txt`, `core/eos/backends/CMakeLists.txt`, `core/eos/cmd/eos/CMakeLists.txt`, `core/eos/core/CMakeLists.txt`, `core/eos/debug/CMakeLists.txt`, `core/eos/drivers/devicetree/CMakeLists.txt`, `core/eos/examples/ble-sensor/CMakeLists.txt`, and 55 more.
+
+## Tests found in the default-branch tree
+
+`core/eboot/tests/CMakeLists.txt`, `core/eboot/tests/unit/test_board_config.c`, `core/eboot/tests/unit/test_board_registry.c`, `core/eboot/tests/unit/test_bootctl.c`, `core/eboot/tests/unit/test_crypto.c`, `core/eboot/tests/unit/test_device_table.c`, `core/eboot/tests/unit/test_multicore.c`, `core/eboot/tests/unit/test_runtime_svc.c`, `core/eos/tests/CMakeLists.txt`, `core/eos/tests/mocks/lvgl.h`, `core/eos/tests/test_config.c`, `core/eos/tests/test_crypto.c`, and 132 more.
+
+## Documented test commands
+
+These commands are reproduced from the inspected root README or contributing guide:
+
+```bash
+pytest                  # configuration in pytest.ini
+```
+
+## Verification baseline
+
+This inventory comes from `master` at [`8b623d5786b5`](https://github.com/embeddedos-org/ebuild/commit/8b623d5786b5f841823f92a5506269f1e155a0f1) and found 144 test-related paths among 1210 files. Re-check the source tree when that commit is no longer current.

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -1,0 +1,29 @@
+# FAQ
+
+## What is `ebuild`?
+
+ebuild — Unified Embedded Build System
+
+## Which branch does this wiki describe?
+
+The latest publication inspected `master` at [`8b623d5786b5`](https://github.com/embeddedos-org/ebuild/commit/8b623d5786b5f841823f92a5506269f1e155a0f1).
+
+## Where are setup instructions?
+
+Start with the [README](https://github.com/embeddedos-org/ebuild/blob/master/README.md), then use [Getting Started](Getting-Started) for a concise map of the checked-in project inputs.
+
+## How do I contribute?
+
+Use the [CONTRIBUTING](https://github.com/embeddedos-org/ebuild/blob/master/CONTRIBUTING.md) and the evidence-backed inventory on [Development](Development). If no root contributing guide exists, inspect the README, repository automation, and recent accepted changes before proposing work.
+
+## How do I run tests?
+
+[Development](Development) lists the 144 test-related paths found in the inspected tree and reproduces recognized test commands only when they appear in the root README or contributing guide.
+
+## How do I report a security issue?
+
+Follow [Security](Security). The source-tree policy status for this publication is: [SECURITY](https://github.com/embeddedos-org/ebuild/blob/master/SECURITY.md)
+
+## Is the wiki authoritative?
+
+No. The [embeddedos-org/ebuild source tree](https://github.com/embeddedos-org/ebuild) is authoritative. The wiki is a repository-specific guide to that source.

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,28 @@
+# Getting Started
+
+## Repository purpose
+
+ebuild — Unified Embedded Build System
+
+## First steps
+
+1. Read the [README](https://github.com/embeddedos-org/ebuild/blob/master/README.md) for the project's supported setup and usage path.
+2. Clone the repository and enter its directory:
+
+```bash
+git clone https://github.com/embeddedos-org/ebuild.git
+cd ebuild
+```
+
+3. Check the root project inputs below before installing dependencies or selecting a build tool.
+4. Review [Development](Development) before changing code, and [Security](Security) before reporting a vulnerability.
+
+## Root project inputs
+
+- `CMakeLists.txt`: CMake build definition.
+- `Dockerfile`: Container build definition.
+- `pyproject.toml`: Python project manifest.
+
+## Scope note
+
+The default branch inspected for this page was `master` at [`8b623d5786b5`](https://github.com/embeddedos-org/ebuild/commit/8b623d5786b5f841823f92a5506269f1e155a0f1). This page intentionally does not invent a universal build command when the repository's own documentation does not provide one.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,22 @@
+# ebuild
+
+ebuild — Unified Embedded Build System
+
+This wiki is a maintained navigation layer for [embeddedos-org/ebuild](https://github.com/embeddedos-org/ebuild). Source files on the `master` default branch remain authoritative for code, commands, policies, and release behavior.
+
+## Start here
+
+- [Getting Started](Getting-Started) explains how to orient yourself using the repository's checked-in entry points.
+- [Development](Development) records the build manifests, contribution guidance, and tests found during the latest source inspection.
+- [Security](Security) points to the repository's vulnerability-reporting policy.
+- [FAQ](FAQ) answers common repository-specific navigation questions.
+
+## Source snapshot
+
+- Default branch: `master`
+- Inspected source commit: [`8b623d5786b5`](https://github.com/embeddedos-org/ebuild/commit/8b623d5786b5f841823f92a5506269f1e155a0f1)
+- Root project overview: [README](https://github.com/embeddedos-org/ebuild/blob/master/README.md)
+- Contribution guidance: [CONTRIBUTING](https://github.com/embeddedos-org/ebuild/blob/master/CONTRIBUTING.md)
+- Security policy: [SECURITY](https://github.com/embeddedos-org/ebuild/blob/master/SECURITY.md)
+
+The wiki was generated from repository content, but it does not replace that content. If a wiki statement and the source tree disagree, follow the source tree and open a documentation correction.

--- a/docs/wiki/Security.md
+++ b/docs/wiki/Security.md
@@ -1,0 +1,13 @@
+# Security
+
+## Reporting vulnerabilities
+
+The repository has a root [SECURITY](https://github.com/embeddedos-org/ebuild/blob/master/SECURITY.md). Follow that policy for supported versions, reporting channels, disclosure expectations, and response details.
+
+Do not publish suspected vulnerabilities in a public issue unless the policy explicitly directs you to do so. Provide a clear description, affected versions or commits, reproduction details, impact, and any known mitigation through the private channel named by the policy.
+
+## Evidence
+
+- Repository: [embeddedos-org/ebuild](https://github.com/embeddedos-org/ebuild)
+- Inspected branch: `master`
+- Inspected commit: [`8b623d5786b5`](https://github.com/embeddedos-org/ebuild/commit/8b623d5786b5f841823f92a5506269f1e155a0f1)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,8 @@
+**ebuild Wiki**
+
+- [Home](Home)
+- [Getting Started](Getting-Started)
+- [Development](Development)
+- [Security](Security)
+- [FAQ](FAQ)
+- [Source Repository](https://github.com/embeddedos-org/ebuild)


### PR DESCRIPTION
## Summary

- add the canonical same-repository linked-issue workflow pinned to organization policy commit `92cb596c773496ec4df76717e8acf0e6b7700f73`
- preserve and extend ebuild's existing agent guidance with repository-specific component boundaries and validation commands
- reconcile the existing pull request template, including repair of malformed control characters, while retaining its summary, change type, testing, checklist, logs, and notes sections
- version the six currently published ebuild Wiki pages under `docs/wiki/`

## Validation

- `python -c "import yaml, pathlib; ..."`: passed; workflow parsed and both policy references equal `92cb596c773496ec4df76717e8acf0e6b7700f73`
- canonical workflow blob comparison after required SHA substitution: passed (`973e19e043e049f08a278caf3bdfbeb4e6ef2584` for both files)
- published Wiki blob comparison: passed for all six files; `docs/wiki/` contains exactly six files
- `npx --yes markdownlint-cli2 --config C:\Users\spatchava\Desktop\task40-tooling-rollout\ebuild\markdownlint-rollout.jsonc AGENTS.md .github/PULL_REQUEST_TEMPLATE.md docs/wiki/*.md`: passed, 8 files, 0 errors; disabled only line length, inline HTML, emphasis-as-heading, first-H1, table-style, and continued-numbering rules to preserve published Wiki text and existing template/agent structure
- `git diff --cached --check`: passed
- `python -m pytest tests/unit/test_ci_gate.py tests/unit/test_documented_commands_exist.py -v --tb=short`: 18 passed
- canonical policy tests at `92cb596c773496ec4df76717e8acf0e6b7700f73`: 18 passed
- workspace diagnostics and change validation: no errors

## Baseline blockers

- Full `python -m pytest tests/ -q --tb=short`: 9 failed, 664 passed, 8 skipped. All nine failures are in `tests/unit/test_index_sync.py` because `PackageRecipe.to_dict` is absent. The untouched `8b623d5786b5f841823f92a5506269f1e155a0f1` baseline reproduces the same nine failures (9 failed, 13 passed for that file).
- `python -m ruff check .`: four findings in unchanged test files (F811, W292, and two E402 findings). The untouched baseline reproduces the same four findings.
- `yamllint` is not installed in the environment; YAML was validated with PyYAML instead.

Fixes #129
